### PR TITLE
Automate admiral releases for new tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,3 +35,47 @@ jobs:
         name: Publish Docker image
         command: |
           make docker-publish
+    - persist_to_workspace:
+        root: .
+        paths:
+          - .
+
+  publish-github-release:
+    docker:
+    - image: circleci/golang:1.11
+    working_directory: /go/pkg/mod/github.com/admiral
+    steps:
+    - attach_workspace:
+        at: .
+    - run:
+        name: Generate output
+        command: |
+          make download-kustomize
+          echo "export PATH=/go/pkg/mod/github.com/admiral:$PATH" >> $BASH_ENV
+          source $BASH_ENV
+          make gen-yaml
+          mkdir ./artifact
+          cd out && tar -zcvf ../artifact/admiral-install-${CIRCLE_TAG}.tar.gz * && cd ..
+    - run:
+        name: Publish Release on GitHub
+        command: |
+          go get github.com/tcnksm/ghr
+          ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${CIRCLE_TAG} ./artifact/
+
+
+workflows:
+  version: 2
+  build-and-release:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/
+      - publish-github-release:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ CUSTOM_RESOURCE_NAME=admiral
 CUSTOM_RESOURCE_VERSION=v1
 
 MAIN_PATH_ADMIRAL=./admiral/cmd/admiral/main.go
-
+OPSYS:=$(shell $(GOCMD) env GOOS)
 
 PATH:=$(GOBIN):$(PATH)
 
@@ -95,7 +95,16 @@ else
 	echo "Skipping publish for branch: $(BRANCH), artifacts are published only from master branch"
 endif
 
-gen-yaml:
+download-kustomize:
+	curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases/latest |\
+	grep browser_download |\
+  	grep $(OPSYS) |\
+  	cut -d '"' -f 4 |\
+  	xargs curl -O -L
+	mv kustomize_kustomize\.v*_$(OPSYS)_amd64 kustomize
+	chmod u+x kustomize
+
+gen-yaml: 
 	mkdir -p ./out/yaml
 	mkdir -p ./out/scripts
 	kustomize build ./install/admiral/overlays/demosinglecluster/ > ./out/yaml/demosinglecluster.yaml


### PR DESCRIPTION
Ref #30 

- Persist workspace to reuse checkout code
- Use `ghr` for easier github releases
- Modify `Makefile` to download `kustomize` before launching `gen-yaml`
- Use `circleci workflow` to `build` for each commit or `build` then `publish-github-release` only on tag push  