### PR TITLE
Fix kustomize download

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ download-kustomize:
 	head -n1 |\
 	cut -d '"' -f 4 |\
 	xargs curl -O -L
-	mv kustomize_kustomize_$(OPSYS)_amd64 kustomize
+	mv kustomize_kustomize.*_$(OPSYS)_amd64 kustomize
 	chmod u+x kustomize
 
 gen-yaml: 

--- a/Makefile
+++ b/Makefile
@@ -96,12 +96,14 @@ else
 endif
 
 download-kustomize:
-	curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases/latest |\
+	curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases |\
 	grep browser_download |\
-  	grep $(OPSYS) |\
-  	cut -d '"' -f 4 |\
-  	xargs curl -O -L
-	mv kustomize_kustomize\.v*_$(OPSYS)_amd64 kustomize
+	grep $(OPSYS) |\
+	grep kustomize_kustomize |\
+	head -n1 |\
+	cut -d '"' -f 4 |\
+	xargs curl -O -L
+	mv kustomize_kustomize_$(OPSYS)_amd64 kustomize
 	chmod u+x kustomize
 
 gen-yaml: 


### PR DESCRIPTION
Kustomize made a release which was not related to the kustomize cli.

The trick is to retrieve all the release and get the last kustomize one.