### PR TITLE
Serviceentry to use a configmap for unique address cache

### DIFF
--- a/admiral/pkg/clusters/registry.go
+++ b/admiral/pkg/clusters/registry.go
@@ -179,6 +179,8 @@ func handleDependencyRecord(identifier string, sourceIdentity string, admiralCac
 
 			for _, deployment := range destDeployment.Deployments {
 
+				svc := getServiceForDeployment(rc, deployment[0], "namespace")
+
 				admiralCache.IdentityClusterCache.Put(destinationCluster, rc.ClusterID, rc.ClusterID)
 
 				deployments := rc.DeploymentController.Cache.Get(destinationCluster)
@@ -187,7 +189,13 @@ func handleDependencyRecord(identifier string, sourceIdentity string, admiralCac
 					continue
 				}
 				//TODO pass deployment
-				tmpSe := createServiceEntry(identifier, rc, config, admiralCache, deployment[0], serviceEntries)
+
+				serviceClusterIp := ""
+				if svc != nil {
+					serviceClusterIp = svc.Spec.ClusterIP
+				}
+
+				tmpSe := createServiceEntry(identifier, rc, config, admiralCache, deployment[0], serviceClusterIp, serviceEntries)
 
 				if tmpSe == nil {
 					continue
@@ -451,7 +459,6 @@ func createServiceEntryForNewServiceOrPod(namespace string, sourceIdentity strin
 		if serviceInstance != nil {
 			serviceClusterIp = serviceInstance.Spec.ClusterIP
 		}
-
 
 		if serviceInstance == nil {
 			continue

--- a/admiral/pkg/clusters/registry.go
+++ b/admiral/pkg/clusters/registry.go
@@ -2,13 +2,13 @@ package clusters
 
 import (
 	"context"
+	"github.com/gogo/protobuf/proto"
 	"github.com/istio-ecosystem/admiral/admiral/pkg/apis/admiral/v1"
 	"github.com/istio-ecosystem/admiral/admiral/pkg/controller/admiral"
 	"github.com/istio-ecosystem/admiral/admiral/pkg/controller/common"
 	"github.com/istio-ecosystem/admiral/admiral/pkg/controller/istio"
 	"github.com/istio-ecosystem/admiral/admiral/pkg/controller/secret"
 	"github.com/istio-ecosystem/admiral/admiral/pkg/controller/util"
-	"github.com/gogo/protobuf/proto"
 	"k8s.io/client-go/rest"
 	"strings"
 	"time"
@@ -179,7 +179,7 @@ func handleDependencyRecord(identifier string, sourceIdentity string, admiralCac
 
 			for _, deployment := range destDeployment.Deployments {
 
-				svc := getServiceForDeployment(rc, deployment[0], "namespace")
+				svc := getServiceForDeployment(rc, deployment[0], deployment[0].Namespace)
 
 				admiralCache.IdentityClusterCache.Put(destinationCluster, rc.ClusterID, rc.ClusterID)
 
@@ -433,7 +433,7 @@ func (sc *ServiceHandler) Added(obj *k8sV1.Service) {
 
 }
 
-func createServiceEntryForNewServiceOrPod(namespace string, sourceIdentity string, remoteRegistry *RemoteRegistry, syncNamespace string) {
+func createServiceEntryForNewServiceOrPod(namespace string, sourceIdentity string, remoteRegistry *RemoteRegistry, syncNamespace string) map[string]*networking.ServiceEntry {
 	//create a service entry, destination rule and virtual service in the local cluster
 	sourceServices := make(map[string]*k8sV1.Service)
 
@@ -526,6 +526,7 @@ func createServiceEntryForNewServiceOrPod(namespace string, sourceIdentity strin
 			//}
 		}
 	}
+	return serviceEntries
 }
 
 func getServiceForDeployment(rc *RemoteController, deployment *k8sAppsV1.Deployment, namespace string) *k8sV1.Service {

--- a/admiral/pkg/clusters/registry_test.go
+++ b/admiral/pkg/clusters/registry_test.go
@@ -2,20 +2,21 @@ package clusters
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	depModel "github.com/istio-ecosystem/admiral/admiral/pkg/apis/admiral/model"
 	"github.com/istio-ecosystem/admiral/admiral/pkg/apis/admiral/v1"
 	"github.com/istio-ecosystem/admiral/admiral/pkg/controller/admiral"
 	"github.com/istio-ecosystem/admiral/admiral/pkg/controller/common"
 	"github.com/istio-ecosystem/admiral/admiral/pkg/controller/istio"
 	"github.com/istio-ecosystem/admiral/admiral/pkg/test"
-	"gotest.tools/assert"
 	networking "istio.io/api/networking/v1alpha3"
 	istioKube "istio.io/istio/pilot/pkg/serviceregistry/kube"
 	k8sAppsV1 "k8s.io/api/apps/v1"
 	k8sCoreV1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
+	"reflect"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -121,9 +122,19 @@ func TestCreateSeWithDrLabels(t *testing.T) {
 		},
 	}
 
-	address := common.NewMap()
+	cacheWithNoEntry := common.ServiceEntryAddressStore{
+		EntryAddresses: map[string]string{},
+		Addresses: []string{},
+	}
 
-	res := createSeWithDrLabels(nil, false, "", "test-se", &se, &des, address)
+	emptyCacheController := test.FakeConfigMapController{
+		GetError: nil,
+		PutError: nil,
+		ConfigmapToReturn: test.BuildFakeConfigMapFromAddressStore(&cacheWithNoEntry),
+	}
+
+
+	res := createSeWithDrLabels(nil, false, "", "test-se", &se, &des, &cacheWithNoEntry, &emptyCacheController)
 
 	if res == nil {
 		t.Fail()
@@ -315,36 +326,6 @@ func TestCreateServiceEntryForNewServiceOrPod(t *testing.T) {
 
 }
 
-
-func TestCreateServiceEntryUseClusterIP(t *testing.T) {
-	p := AdmiralParams{
-		KubeconfigPath: "testdata/fake.config",
-	}
-	rr, _ := InitAdmiral(context.Background(), p)
-
-	rc, _ := createMockRemoteController(func(i interface{}) {
-		res := i.(istio.Config)
-		se, ok := res.Spec.(*networking.ServiceEntry)
-		if ok {
-			if se.Hosts[0] != "dev.bar.global" {
-				t.Fail()
-			}
-		}
-	})
-
-	rr.remoteControllers["test.cluster"] = rc
-	rc.ServiceController.Cache.Get("test").Service["test"][0].Spec.ClusterIP = "1.2.3.4"
-
-	serviceentries := createServiceEntryForNewServiceOrPod("test", "bar", rr, "sync")
-
-
-	for key, value := range serviceentries{
-		fmt.Println("Key:", key, "Value:", value.Addresses[0])
-		assert.Equal(t, value.Addresses[0], "1.2.3.4", "Expected SE address to be equal to the cluster IP but it was not")
-	}
-}
-
-
 func TestAdded(t *testing.T) {
 
 	p := AdmiralParams{
@@ -497,3 +478,146 @@ func TestPodHandler(t *testing.T) {
 
 	ph.Deleted(&pod)
 }
+
+func TestGetLocalAddressForSe(t *testing.T) {
+	t.Parallel()
+	cacheWithEntry := common.ServiceEntryAddressStore{
+		EntryAddresses: map[string]string{"e2e.a.mesh": common.LocalAddressPrefix + ".10.1"},
+		Addresses: []string{common.LocalAddressPrefix + ".10.1"},
+	}
+	cacheWithNoEntry := common.ServiceEntryAddressStore{
+		EntryAddresses: map[string]string{},
+		Addresses: []string{},
+	}
+	cacheWith255Entries := common.ServiceEntryAddressStore{
+		EntryAddresses: map[string]string{},
+		Addresses: []string{},
+	}
+
+	for i := 1; i <= 255; i++ {
+		address :=  common.LocalAddressPrefix + ".10." + strconv.Itoa(i)
+		cacheWith255Entries.EntryAddresses[strconv.Itoa(i) + ".mesh"] = address
+		cacheWith255Entries.Addresses = append(cacheWith255Entries.Addresses, address)
+	}
+
+	emptyCacheController := test.FakeConfigMapController{
+		GetError: nil,
+		PutError: nil,
+		ConfigmapToReturn: test.BuildFakeConfigMapFromAddressStore(&cacheWithNoEntry),
+	}
+
+	cacheController := test.FakeConfigMapController{
+		GetError: nil,
+		PutError: nil,
+		ConfigmapToReturn: test.BuildFakeConfigMapFromAddressStore(&cacheWithEntry),
+	}
+
+	cacheControllerWith255Entries := test.FakeConfigMapController{
+		GetError: nil,
+		PutError: nil,
+		ConfigmapToReturn: test.BuildFakeConfigMapFromAddressStore(&cacheWith255Entries),
+	}
+
+	cacheControllerGetError := test.FakeConfigMapController{
+		GetError: errors.New("BAD THINGS HAPPENED"),
+		PutError: nil,
+		ConfigmapToReturn: test.BuildFakeConfigMapFromAddressStore(&cacheWithEntry),
+	}
+
+	cacheControllerPutError := test.FakeConfigMapController{
+		PutError: errors.New("BAD THINGS HAPPENED"),
+		GetError: nil,
+		ConfigmapToReturn: test.BuildFakeConfigMapFromAddressStore(&cacheWithEntry),
+	}
+
+
+	testCases := []struct {
+		name   string
+		seName   string
+		seAddressCache  common.ServiceEntryAddressStore
+		wantAddess string
+		cacheController admiral.ConfigMapControllerInterface
+		expectedCacheUpdate bool
+		wantedError error
+	}{
+		{
+			name: "should return new available address",
+			seName: "e2e.a.mesh",
+			seAddressCache: cacheWithNoEntry,
+			wantAddess: common.LocalAddressPrefix + ".10.1",
+			cacheController: &emptyCacheController,
+			expectedCacheUpdate: true,
+			wantedError: nil,
+		},
+		{
+			name: "should return address from map",
+			seName: "e2e.a.mesh",
+			seAddressCache: cacheWithEntry,
+			wantAddess: common.LocalAddressPrefix + ".10.1",
+			cacheController: &cacheController,
+			expectedCacheUpdate: false,
+			wantedError: nil,
+		},
+		{
+			name: "should return new available address",
+			seName: "e2e.b.mesh",
+			seAddressCache: cacheWithEntry,
+			wantAddess: common.LocalAddressPrefix + ".10.2",
+			cacheController: &cacheController,
+			expectedCacheUpdate: true,
+			wantedError: nil,
+		},
+		{
+			name: "should return new available address in higher subnet",
+			seName: "e2e.a.mesh",
+			seAddressCache: cacheWith255Entries,
+			wantAddess: common.LocalAddressPrefix + ".11.1",
+			cacheController: &cacheControllerWith255Entries,
+			expectedCacheUpdate: true,
+			wantedError: nil,
+		},
+		{
+			name: "should gracefully propagate get error",
+			seName: "e2e.a.mesh",
+			seAddressCache: cacheWith255Entries,
+			wantAddess: "",
+			cacheController: &cacheControllerGetError,
+			expectedCacheUpdate: true,
+			wantedError: errors.New("BAD THINGS HAPPENED"),
+		},
+		{
+			name: "Should not return address on put error",
+			seName: "e2e.abcdefghijklmnop.mesh",
+			seAddressCache: cacheWith255Entries,
+			wantAddess: "",
+			cacheController: &cacheControllerPutError,
+			expectedCacheUpdate: true,
+			wantedError: errors.New("BAD THINGS HAPPENED"),
+		},
+	}
+
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+			seAddress, needsCacheUpdate, err := GetLocalAddressForSe(c.seName, &c.seAddressCache, c.cacheController)
+			if c.wantAddess != "" {
+				if !reflect.DeepEqual(seAddress, c.wantAddess) {
+					t.Errorf("Wanted se address: %s, got: %s", c.wantAddess, seAddress)
+				}
+				if err==nil && c.wantedError==nil {
+					//we're fine
+				} else if err.Error() != c.wantedError.Error() {
+					t.Errorf("Error mismatch. Expected %v but got %v", c.wantedError, err)
+				}
+				if needsCacheUpdate != c.expectedCacheUpdate {
+					t.Errorf("Expected %v, got %v for needs cache update", c.expectedCacheUpdate, needsCacheUpdate)
+				}
+			} else {
+				if seAddress != "" {
+					t.Errorf("Unexpectedly found address: %s", seAddress)
+				}
+			}
+		})
+	}
+
+}
+

--- a/admiral/pkg/controller/admiral/configmap.go
+++ b/admiral/pkg/controller/admiral/configmap.go
@@ -1,0 +1,125 @@
+package admiral
+
+import (
+	"errors"
+	"github.com/istio-ecosystem/admiral/admiral/pkg/controller/common"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+	"k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"strings"
+)
+
+const configmapName  = "se-address-configmap"
+
+type ConfigMapControllerInterface interface {
+	GetConfigMap() (*v1.ConfigMap, error)
+	PutConfigMap(newMap *v1.ConfigMap) error
+}
+
+type ConfigMapController struct {
+	K8sClient kubernetes.Interface
+	ConfigmapNamespace string
+}
+
+//todo this is a temp state, eventually changes will have to be made to give each cluster it's own configmap
+
+func NewConfigMapController(kubeconfigPath string, namespaceToUse string) (*ConfigMapController, error) {
+
+	if kubeconfigPath == "" {
+		config, err := rest.InClusterConfig()
+		if err != nil {
+			return nil, err
+		}
+		client, err := kubernetes.NewForConfig(config)
+		if err != nil {
+			return nil, err
+		}
+		controller := ConfigMapController{
+			K8sClient: client,
+			ConfigmapNamespace: namespaceToUse,
+		}
+		return &controller, nil
+	} else {
+		// use the current context in kubeconfig
+		config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+		if err != nil {
+			return nil, err
+		}
+
+		// create the clientset
+		client, err := kubernetes.NewForConfig(config)
+		if err != nil {
+			return nil, err
+		}
+		controller := ConfigMapController{
+			K8sClient: client,
+			ConfigmapNamespace: namespaceToUse,
+		}
+		return &controller, nil
+	}
+
+}
+
+func (c *ConfigMapController) GetConfigMap() (*v1.ConfigMap, error) {
+	getOpts := metaV1.GetOptions{}
+	configMap, err := c.K8sClient.CoreV1().ConfigMaps(c.ConfigmapNamespace).Get(configmapName, getOpts)
+
+	if err == nil {
+		return configMap, err
+	}
+
+	if strings.Contains(err.Error(), "not found") {
+		cm := v1.ConfigMap{}
+		cm.Name = configmapName
+		cm.Namespace = c.ConfigmapNamespace
+		configMap, err = c.K8sClient.CoreV1().ConfigMaps(c.ConfigmapNamespace).Create(&cm)
+	}
+
+	return configMap, err
+
+}
+
+func (c *ConfigMapController) PutConfigMap(newMap *v1.ConfigMap) error {
+	err := validateConfigmapBeforePutting(newMap)
+	if err != nil {
+		return err
+	}
+	_, err = c.K8sClient.CoreV1().ConfigMaps(c.ConfigmapNamespace).Update(newMap)
+	return err
+}
+
+func GetServiceEntryStateFromConfigmap(configmap *v1.ConfigMap) *common.ServiceEntryAddressStore {
+
+	bytes := []byte(configmap.Data["serviceEntryAddressStore"])
+	addressStore := common.ServiceEntryAddressStore{}
+	err := yaml.Unmarshal(bytes, &addressStore)
+
+	if err != nil {
+		logrus.Errorf("Could not unmarshal configmap data. Double check the configmap format. %v", err)
+		return nil
+	}
+	if addressStore.Addresses == nil {
+		addressStore.Addresses = []string{}
+	}
+	if addressStore.EntryAddresses == nil {
+		addressStore.EntryAddresses = map[string]string{}
+	}
+
+
+	return &addressStore
+}
+
+func validateConfigmapBeforePutting(cm *v1.ConfigMap) error {
+	if cm.ResourceVersion == "" {
+		return errors.New("resourceversion required") //without it, we can't be sure someone else didn't put something between our read and write
+	}
+	store := GetServiceEntryStateFromConfigmap(cm)
+	if len(store.EntryAddresses) != len(store.Addresses) {
+		return errors.New("address cache length mismatch") //should be impossible. We're in a state where the list of addresses doesn't match the map of se:address. Something's been missed and must be fixed
+	}
+	return nil
+}

--- a/admiral/pkg/controller/admiral/configmap_test.go
+++ b/admiral/pkg/controller/admiral/configmap_test.go
@@ -1,0 +1,69 @@
+package admiral
+
+import (
+	"errors"
+	"github.com/istio-ecosystem/admiral/admiral/pkg/controller/common"
+	"gopkg.in/yaml.v2"
+	"k8s.io/api/core/v1"
+	"testing"
+)
+
+func buildFakeConfigMapFromAddressStore(addressStore *common.ServiceEntryAddressStore, resourceVersion string) *v1.ConfigMap{
+	bytes,_ := yaml.Marshal(addressStore)
+
+	cm := v1.ConfigMap{
+		Data: map[string]string{"serviceEntryAddressStore": string(bytes)},
+	}
+	cm.Name="se-address-configmap"
+	cm.Namespace="admiral-remote-ctx"
+	cm.ResourceVersion=resourceVersion
+	return &cm
+}
+
+func TestValidateConfigmapBeforePutting(t *testing.T) {
+
+	legalStore := common.ServiceEntryAddressStore{
+		EntryAddresses: map[string]string{"e2e.a.mesh": common.LocalAddressPrefix + ".10.1"},
+		Addresses: []string{common.LocalAddressPrefix + ".10.1"},
+	}
+
+	illegalStore := common.ServiceEntryAddressStore{
+		EntryAddresses: map[string]string{"e2e.a.mesh": common.LocalAddressPrefix + ".10.1"},
+		Addresses: []string{common.LocalAddressPrefix + ".10.1","1.2.3.4"},
+	}
+
+	testCases := []struct{
+		name string
+		configMap	 *v1.ConfigMap
+		expectedError	error
+	}{
+		{
+			name: "should not throw error on legal configmap",
+			configMap:     buildFakeConfigMapFromAddressStore(&legalStore, "123"),
+			expectedError: nil,
+		},
+		{
+			name: "should throw error on no resourceversion",
+			configMap:     buildFakeConfigMapFromAddressStore(&legalStore, ""),
+			expectedError: errors.New("resourceversion required"),
+		},
+		{
+			name: "should throw error on length mismatch",
+			configMap:     buildFakeConfigMapFromAddressStore(&illegalStore, "123"),
+			expectedError: errors.New("address cache length mismatch"),
+		},
+
+	}
+
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+			errorResult := validateConfigmapBeforePutting(c.configMap)
+			if errorResult==nil && c.expectedError==nil {
+				//we're fine
+			} else if errorResult.Error() != c.expectedError.Error() {
+				t.Errorf("Error mismatch. Expected %v but got %v", c.expectedError, errorResult)
+			}
+		})
+	}
+
+}

--- a/admiral/pkg/controller/common/common.go
+++ b/admiral/pkg/controller/common/common.go
@@ -84,6 +84,7 @@ func GetSAN(domain string, deployment *k8sAppsV1.Deployment, identifier string) 
 func GetLocalAddressForSe(seName string, seAddressCache *Map) string {
 	var address = seAddressCache.Get(seName)
 	if len(address) == 0 {
+		logrus.Warn("Falling back to legacy ServiceEntry address creation (This should not happen). SeName=%v", seName)
 		secondIndex := (len(seAddressCache.Map()) / 255) + 10
 		firstIndex := (len(seAddressCache.Map()) % 255) + 1
 		address = LocalAddressPrefix + Sep + strconv.Itoa(secondIndex) + Sep + strconv.Itoa(firstIndex)

--- a/admiral/pkg/controller/common/common.go
+++ b/admiral/pkg/controller/common/common.go
@@ -4,7 +4,6 @@ import (
 	"github.com/sirupsen/logrus"
 	k8sAppsV1 "k8s.io/api/apps/v1"
 	k8sV1 "k8s.io/api/core/v1"
-	"strconv"
 )
 
 const (
@@ -79,18 +78,6 @@ func GetSAN(domain string, deployment *k8sAppsV1.Deployment, identifier string) 
 	} else {
 		return SpiffePrefix + identifierVal
 	}
-}
-
-func GetLocalAddressForSe(seName string, seAddressCache *Map) string {
-	var address = seAddressCache.Get(seName)
-	if len(address) == 0 {
-		logrus.Warn("Falling back to legacy ServiceEntry address creation (This should not happen). SeName=%v", seName)
-		secondIndex := (len(seAddressCache.Map()) / 255) + 10
-		firstIndex := (len(seAddressCache.Map()) % 255) + 1
-		address = LocalAddressPrefix + Sep + strconv.Itoa(secondIndex) + Sep + strconv.Itoa(firstIndex)
-		seAddressCache.Put(seName, address)
-	}
-	return address
 }
 
 func GetNodeLocality(node *k8sV1.Node) string {

--- a/admiral/pkg/controller/common/common_test.go
+++ b/admiral/pkg/controller/common/common_test.go
@@ -5,69 +5,8 @@ import (
 	v12 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
-	"strconv"
 	"testing"
 )
-
-func TestGetLocalAddressForSe(t *testing.T) {
-	t.Parallel()
-	cacheWithEntry := NewMap()
-	cacheWithNoEntry := NewMap()
-	cacheWith255Entries := NewMap()
-	cacheWithEntry.Put("dev.a.global", LocalAddressPrefix + ".10.1")
-
-	for i := 1; i <= 255; i++ {
-		cacheWith255Entries.Put(strconv.Itoa(i) + ".global", LocalAddressPrefix + ".10." + strconv.Itoa(i))
-	}
-
-	testCases := []struct {
-		name   string
-		seName   string
-		seAddressCache  *Map
-		wantAddess string
-	}{
-		{
-			name: "should return new available address",
-			seName: "dev.a.global",
-			seAddressCache: cacheWithNoEntry,
-			wantAddess: LocalAddressPrefix + ".10.1",
-		},
-		{
-			name: "should return address from map",
-			seName: "dev.a.global",
-			seAddressCache: cacheWithEntry,
-			wantAddess: LocalAddressPrefix + ".10.1",
-		},
-		{
-			name: "should return new available address",
-			seName: "dev.b.global",
-			seAddressCache: cacheWithEntry,
-			wantAddess: LocalAddressPrefix + ".10.2",
-		},
-		{
-			name: "should return new available address in higher subnet",
-			seName: "dev.a.global",
-			seAddressCache: cacheWith255Entries,
-			wantAddess: LocalAddressPrefix + ".11.1",
-		},
-	}
-
-	for _, c := range testCases {
-		t.Run(c.name, func(t *testing.T) {
-			seAddress := GetLocalAddressForSe(c.seName, c.seAddressCache)
-			if c.wantAddess != "" {
-				if !reflect.DeepEqual(seAddress, c.wantAddess) {
-					t.Errorf("Wanted se address: %s, got: %s", c.wantAddess, seAddress)
-				}
-			} else {
-				if seAddress != "" {
-					t.Errorf("Unexpectedly found address: %s", seAddress)
-				}
-			}
-		})
-	}
-
-}
 
 func TestGetSAN(t *testing.T) {
 	t.Parallel()

--- a/admiral/pkg/controller/common/types.go
+++ b/admiral/pkg/controller/common/types.go
@@ -15,6 +15,11 @@ type MapOfMaps struct {
 	mutex *sync.Mutex
 }
 
+type ServiceEntryAddressStore struct {
+	EntryAddresses	map[string]string `yaml:"entry-addresses,omitempty"`
+	Addresses		[]string   `yaml:"addresses,omitempty"` //trading space for efficiency - this will give a quick way to validate that the address is unique
+}
+
 func NewMap() *Map {
   n := new(Map)
   n.cache = make(map[string]string)

--- a/admiral/pkg/controller/util/util.go
+++ b/admiral/pkg/controller/util/util.go
@@ -27,3 +27,12 @@ func Subset(m1 map[string]string, m2 map[string]string) bool {
 	}
 	return true;
 }
+
+func Contains(vs []string, t string) bool {
+	for _, v := range vs {
+		if v == t {
+			return true
+		}
+	}
+	return false
+}

--- a/admiral/pkg/test/types.go
+++ b/admiral/pkg/test/types.go
@@ -1,0 +1,33 @@
+package test
+
+import (
+	"github.com/istio-ecosystem/admiral/admiral/pkg/controller/common"
+	"gopkg.in/yaml.v2"
+	k8sCoreV1 "k8s.io/api/core/v1"
+
+)
+
+type FakeConfigMapController struct {
+	GetError error
+	PutError error
+	ConfigmapToReturn *k8sCoreV1.ConfigMap
+}
+
+func (c *FakeConfigMapController) GetConfigMap() (*k8sCoreV1.ConfigMap, error) {
+	return c.ConfigmapToReturn, c.GetError
+}
+
+func (c *FakeConfigMapController) PutConfigMap(newMap *k8sCoreV1.ConfigMap) error {
+	return c.PutError
+}
+
+func BuildFakeConfigMapFromAddressStore(addressStore *common.ServiceEntryAddressStore) *k8sCoreV1.ConfigMap{
+	bytes,_ := yaml.Marshal(addressStore)
+
+	cm := k8sCoreV1.ConfigMap{
+		Data: map[string]string{"serviceEntryAddressStore": string(bytes)},
+	}
+	cm.Name="se-address-configmap"
+	cm.Namespace="admiral-remote-ctx"
+	return &cm
+}

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	google.golang.org/grpc v1.18.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/yaml.v2 v2.2.2
+	gotest.tools v2.2.0+incompatible
 	istio.io/api v0.0.0-20190213184321-d817a1a3e29a
 	istio.io/istio v0.0.0-20190214070811-6113e155ac85
 	k8s.io/api v0.0.0-20190118113203-912cbe2bfef3

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,7 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
@@ -259,6 +260,8 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
+gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJdjuHRquDANNeA4x7B8WQ9o=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
We noticed a bug where serviceentries are occasionally created with duplicate IPs. This is fixing that.

Still pending validation + writing tests.