### PR TITLE
Making labels configurable

### DIFF
--- a/admiral/cmd/admiral/cmd/root.go
+++ b/admiral/cmd/admiral/cmd/root.go
@@ -71,11 +71,11 @@ func GetRootCmd(args []string) *cobra.Command {
 		"Prefix to use when creating SAN for Service Entries")
 	rootCmd.PersistentFlags().StringVar(&params.SecretResolver, "secret_resolver", "",
 		"Type of resolver to use to fetch kubeconfig for monitored clusters")
-	rootCmd.PersistentFlags().StringVar(&params.LabelSet.DeploymentLabel, "deployment_label", "istio-injected",
+	rootCmd.PersistentFlags().StringVar(&params.LabelSet.DeploymentLabel, "deployment_label", "sidecar.istio.io/inject",
 		"The label, on a deployment, which must be set to \"True\" for Admiral to listen on the deployment")
 	rootCmd.PersistentFlags().StringVar(&params.LabelSet.SubsetLabel, "subset_label", "subset",
 		"The label, on a deployment, tells admiral which target group this deployment is a part of. Used for traffic splits via the Global Traffic Policy object")
-	rootCmd.PersistentFlags().StringVar(&params.LabelSet.NamespaceSidecarInjectionLabel, "namespace_injected_label", "sidecar.istio.io/inject",
+	rootCmd.PersistentFlags().StringVar(&params.LabelSet.NamespaceSidecarInjectionLabel, "namespace_injected_label", "istio-injection",
 		"The label key, on a namespace, which tells Istio to perform sidecar injection")
 	rootCmd.PersistentFlags().StringVar(&params.LabelSet.NamespaceSidecarInjectionLabelValue, "namespace_injected_value", "enabled",
 		"The label value, on a namespace, which tells Istio to perform sidecar injection")

--- a/admiral/cmd/admiral/cmd/root.go
+++ b/admiral/cmd/admiral/cmd/root.go
@@ -75,7 +75,7 @@ func GetRootCmd(args []string) *cobra.Command {
 		"The label, on a deployment, which must be set to \"True\" for Admiral to listen on the deployment")
 	rootCmd.PersistentFlags().StringVar(&params.LabelSet.TargetGroupLabel, "target_group_label", "target-group",
 		"The label, on a deployment, tells admiral which target group this deployment is a part of. Used for traffic splits via the Global Traffic Policy object")
-	rootCmd.PersistentFlags().StringVar(&params.LabelSet.TargetGroupLabel, "namespace_injected_label", "istio-injection",
+	rootCmd.PersistentFlags().StringVar(&params.LabelSet.TargetGroupLabel, "namespace_injected_label", "sidecar.istio.io/inject",
 		"The label key, on a namespace, which tells Istio to perform sidecar injection")
 	rootCmd.PersistentFlags().StringVar(&params.LabelSet.TargetGroupLabel, "namespace_injected_value", "enabled",
 		"The label value, on a namespace, which tells Istio to perform sidecar injection")

--- a/admiral/cmd/admiral/cmd/root.go
+++ b/admiral/cmd/admiral/cmd/root.go
@@ -71,8 +71,8 @@ func GetRootCmd(args []string) *cobra.Command {
 		"Prefix to use when creating SAN for Service Entries")
 	rootCmd.PersistentFlags().StringVar(&params.SecretResolver, "secret_resolver", "",
 		"Type of resolver to use to fetch kubeconfig for monitored clusters")
-	rootCmd.PersistentFlags().StringVar(&params.LabelSet.DeploymentLabel, "deployment_label", "sidecar.istio.io/inject",
-		"The label, on a deployment, which must be set to \"True\" for Admiral to listen on the deployment")
+	rootCmd.PersistentFlags().StringVar(&params.LabelSet.DeploymentAnnotation, "deployment_annotation", "sidecar.istio.io/inject",
+		"The annotation, on a deployment, which must be set to \"true\" for Admiral to listen on the deployment")
 	rootCmd.PersistentFlags().StringVar(&params.LabelSet.SubsetLabel, "subset_label", "subset",
 		"The label, on a deployment, tells admiral which target group this deployment is a part of. Used for traffic splits via the Global Traffic Policy object")
 	rootCmd.PersistentFlags().StringVar(&params.LabelSet.NamespaceSidecarInjectionLabel, "namespace_injected_label", "istio-injection",

--- a/admiral/cmd/admiral/cmd/root.go
+++ b/admiral/cmd/admiral/cmd/root.go
@@ -71,6 +71,14 @@ func GetRootCmd(args []string) *cobra.Command {
 		"Prefix to use when creating SAN for Service Entries")
 	rootCmd.PersistentFlags().StringVar(&params.SecretResolver, "secret_resolver", "",
 		"Type of resolver to use to fetch kubeconfig for monitored clusters")
+	rootCmd.PersistentFlags().StringVar(&params.LabelSet.DeploymentLabel, "deployment_label", "istio-injected",
+		"The label, on a deployment, which must be set to \"True\" for Admiral to listen on the deployment")
+	rootCmd.PersistentFlags().StringVar(&params.LabelSet.TargetGroupLabel, "target_group_label", "target-group",
+		"The label, on a deployment, tells admiral which target group this deployment is a part of. Used for traffic splits via the Global Traffic Policy object")
+	rootCmd.PersistentFlags().StringVar(&params.LabelSet.TargetGroupLabel, "namespace_injected_label", "istio-injection",
+		"The label key, on a namespace, which tells Istio to perform sidecar injection")
+	rootCmd.PersistentFlags().StringVar(&params.LabelSet.TargetGroupLabel, "namespace_injected_value", "enabled",
+		"The label value, on a namespace, which tells Istio to perform sidecar injection")
 	loggingOptions.AttachCobraFlags(rootCmd)
 
 	return rootCmd

--- a/admiral/cmd/admiral/cmd/root.go
+++ b/admiral/cmd/admiral/cmd/root.go
@@ -73,11 +73,13 @@ func GetRootCmd(args []string) *cobra.Command {
 		"Type of resolver to use to fetch kubeconfig for monitored clusters")
 	rootCmd.PersistentFlags().StringVar(&params.LabelSet.DeploymentLabel, "deployment_label", "istio-injected",
 		"The label, on a deployment, which must be set to \"True\" for Admiral to listen on the deployment")
-	rootCmd.PersistentFlags().StringVar(&params.LabelSet.TargetGroupLabel, "target_group_label", "target-group",
+	rootCmd.PersistentFlags().StringVar(&params.LabelSet.SubsetLabel, "subset_label", "subset",
 		"The label, on a deployment, tells admiral which target group this deployment is a part of. Used for traffic splits via the Global Traffic Policy object")
-	rootCmd.PersistentFlags().StringVar(&params.LabelSet.TargetGroupLabel, "namespace_injected_label", "sidecar.istio.io/inject",
+	rootCmd.PersistentFlags().StringVar(&params.LabelSet.NamespaceSidecarInjectionLabel, "namespace_injected_label", "sidecar.istio.io/inject",
 		"The label key, on a namespace, which tells Istio to perform sidecar injection")
-	rootCmd.PersistentFlags().StringVar(&params.LabelSet.TargetGroupLabel, "namespace_injected_value", "enabled",
+	rootCmd.PersistentFlags().StringVar(&params.LabelSet.NamespaceSidecarInjectionLabelValue, "namespace_injected_value", "enabled",
+		"The label value, on a namespace, which tells Istio to perform sidecar injection")
+	rootCmd.PersistentFlags().StringVar(&params.LabelSet.AdmiralIgnoreLabel, "admiral_ignore_label", "admiral-ignore",
 		"The label value, on a namespace, which tells Istio to perform sidecar injection")
 	loggingOptions.AttachCobraFlags(rootCmd)
 

--- a/admiral/pkg/clusters/registry.go
+++ b/admiral/pkg/clusters/registry.go
@@ -49,6 +49,7 @@ type AdmiralParams struct {
 	EnableSAN                  bool
 	SANPrefix                  string
 	SecretResolver             string
+	LabelSet				   *common.LabelSet
 }
 
 func (b AdmiralParams) String() string {

--- a/admiral/pkg/controller/admiral/deployment.go
+++ b/admiral/pkg/controller/admiral/deployment.go
@@ -35,7 +35,7 @@ type DeploymentController struct {
 }
 
 type deploymentCache struct {
-	//map of dependencies key=identity value array of onboarded identitys
+	//map of dependencies key=identity value array of onboarded identities
 	cache map[string]*DeploymentClusterEntry
 	mutex *sync.Mutex
 }

--- a/admiral/pkg/controller/admiral/deployment.go
+++ b/admiral/pkg/controller/admiral/deployment.go
@@ -174,7 +174,7 @@ func (d *DeploymentController) shouldIgnoreBasedOnLabels(deployment *k8sAppsV1.D
 	if deployment.Spec.Template.Labels[d.labelSet.AdmiralIgnoreLabel] == "true" { //if we should ignore, do that and who cares what else is there
 		return true
 	}
-	if deployment.Spec.Template.Labels[d.labelSet.DeploymentLabel] != "true" { //Not sidecar injected, we don't want to inject
+	if deployment.Spec.Template.Annotations[d.labelSet.DeploymentAnnotation] != "true" { //Not sidecar injected, we don't want to inject
 			return true
 	}
 	return false //labels are fine, we should not ignore

--- a/admiral/pkg/controller/admiral/deployment_test.go
+++ b/admiral/pkg/controller/admiral/deployment_test.go
@@ -1,0 +1,78 @@
+package admiral
+
+import (
+	"github.com/istio-ecosystem/admiral/admiral/pkg/controller/common"
+	"github.com/istio-ecosystem/admiral/admiral/pkg/test"
+	"k8s.io/api/apps/v1"
+	"sync"
+	"testing"
+)
+
+func TestDeploymentController_Added(t *testing.T) {
+	//Deployments with the correct label are added to the cache
+	mdh := test.MockDeploymentHandler{}
+	cache := deploymentCache{
+		cache: map[string]*DeploymentClusterEntry{},
+		mutex: &sync.Mutex{},
+	}
+	labelset := common.LabelSet{
+		DeploymentLabel: "istio-injected",
+	}
+	depController := DeploymentController{
+		DeploymentHandler: &mdh,
+		Cache:             &cache,
+		labelSet:          labelset,
+	}
+	deployment := v1.Deployment{}
+	deployment.Spec.Template.Labels = map[string]string{"identity": "id", "istio-injected": "true"}
+	deploymentWithBadLabels := v1.Deployment{}
+	deploymentWithBadLabels.Spec.Template.Labels = map[string]string{"identity": "id", "random-label": "true"}
+
+	testCases := []struct {
+		name               string
+		deployment         *v1.Deployment
+		expectedDeployment *v1.Deployment
+		expectedCacheSize  int
+	}{
+		{
+			name:               "Expects deployment to be added to the cache when the correct label is present",
+			deployment:         &deployment,
+			expectedDeployment: &deployment,
+			expectedCacheSize:  1,
+		},
+		{
+			name:               "Expects deployment to not be added to the cache when the correct label is not present",
+			deployment:         &deploymentWithBadLabels,
+			expectedDeployment: nil,
+			expectedCacheSize:  0,
+		},
+	}
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+			depController.Cache.cache = map[string]*DeploymentClusterEntry{}
+			depController.Added(c.deployment)
+			if c.expectedDeployment == nil {
+				if len(depController.Cache.cache) != 0 {
+					t.Errorf("Cache should be empty if expected deployment is nil")
+				}
+			} else if len(depController.Cache.cache["id"].Deployments) < 1 && len(depController.Cache.cache["id"].Deployments[""]) != c.expectedCacheSize {
+				t.Errorf("Deployment controller cache the wrong size. Got %v, expected %v", len(depController.Cache.cache["id"].Deployments[""]), c.expectedCacheSize)
+			} else if depController.Cache.cache["id"].Deployments[""][0] != &deployment {
+				t.Errorf("Incorrect deployment added to deployment controller cache. Got %v expected %v", depController.Cache.cache["id"].Deployments[""][0], deployment)
+			}
+
+		})
+	}
+
+}
+
+//
+//func (d *DeploymentController) Added(ojb interface{}) {
+//	deployment := ojb.(*k8sAppsV1.Deployment)
+//	key := d.Cache.getKey(deployment)
+//	if len(key) > 0 && deployment.Spec.Template.Labels[d.labelSet.DeploymentLabel] == "true" {
+//		d.Cache.AppendDeploymentToCluster(key, deployment)
+//		d.DeploymentHandler.Added(deployment)
+//	}
+//
+//}

--- a/admiral/pkg/controller/admiral/deployment_test.go
+++ b/admiral/pkg/controller/admiral/deployment_test.go
@@ -76,3 +76,7 @@ func TestDeploymentController_Added(t *testing.T) {
 	}
 
 }
+
+func TestDeploymentController_GetDeployments(t *testing.T) {
+
+}

--- a/admiral/pkg/controller/admiral/deployment_test.go
+++ b/admiral/pkg/controller/admiral/deployment_test.go
@@ -20,8 +20,8 @@ func TestDeploymentController_Added(t *testing.T) {
 		mutex: &sync.Mutex{},
 	}
 	labelset := common.LabelSet{
-		DeploymentLabel: "istio-injected",
-		AdmiralIgnoreLabel: "admiral-ignore",
+		DeploymentAnnotation: "sidecar.istio.io/inject",
+		AdmiralIgnoreLabel:   "admiral-ignore",
 	}
 	depController := DeploymentController{
 		DeploymentHandler: &mdh,
@@ -30,10 +30,12 @@ func TestDeploymentController_Added(t *testing.T) {
 	}
 	deployment := k8sAppsV1.Deployment{}
 	deployment.Spec.Template.Labels = map[string]string{"identity": "id", "istio-injected": "true"}
+	deployment.Spec.Template.Annotations = map[string]string{"sidecar.istio.io/inject": "true"}
 	deploymentWithBadLabels := k8sAppsV1.Deployment{}
 	deploymentWithBadLabels.Spec.Template.Labels = map[string]string{"identity": "id", "random-label": "true"}
 	deploymentWithIgnoreLabels := k8sAppsV1.Deployment{}
 	deploymentWithIgnoreLabels.Spec.Template.Labels = map[string]string{"identity": "id", "istio-injected": "true", "admiral-ignore": "true"}
+	deploymentWithIgnoreLabels.Spec.Template.Annotations = map[string]string{"sidecar.istio.io/inject": "true"}
 
 	testCases := []struct {
 		name               string
@@ -87,10 +89,10 @@ func TestDeploymentController_GetDeployments(t *testing.T) {
 
 	depController := DeploymentController{
 		labelSet: common.LabelSet{
-			DeploymentLabel:                    "istio-injected",
+			DeploymentAnnotation:                "sidecar.istio.io/inject",
 			NamespaceSidecarInjectionLabel:      "istio-injection",
 			NamespaceSidecarInjectionLabelValue: "enabled",
-			AdmiralIgnoreLabel:  "admiral-ignore",
+			AdmiralIgnoreLabel:                  "admiral-ignore",
 		},
 	}
 
@@ -110,14 +112,17 @@ func TestDeploymentController_GetDeployments(t *testing.T) {
 	deployment.Namespace = "test-ns"
 	deployment.Name="deployment"
 	deployment.Spec.Template.Labels = map[string]string{"identity": "id", "istio-injected": "true"}
+	deployment.Spec.Template.Annotations = map[string]string{"sidecar.istio.io/inject": "true"}
 	deploymentWithBadLabels := k8sAppsV1.Deployment{}
 	deploymentWithBadLabels.Namespace = "test-ns"
 	deploymentWithBadLabels.Name="deploymentWithBadLabels"
 	deploymentWithBadLabels.Spec.Template.Labels = map[string]string{"identity": "id", "random-label": "true"}
+	deploymentWithBadLabels.Spec.Template.Annotations = map[string]string{"woo": "yay"}
 	deploymentWithIgnoreLabels := k8sAppsV1.Deployment{}
 	deploymentWithIgnoreLabels.Namespace = "test-ns"
 	deploymentWithIgnoreLabels.Name="deploymentWithIgnoreLabels"
 	deploymentWithIgnoreLabels.Spec.Template.Labels = map[string]string{"identity": "id", "istio-injected": "true", "admiral-ignore": "true"}
+	deploymentWithIgnoreLabels.Spec.Template.Annotations = map[string]string{"sidecar.istio.io/inject": "true"}
 	_, err = client.AppsV1().Deployments("test-ns").Create(&deployment)
 	_, err = client.AppsV1().Deployments("test-ns").Create(&deploymentWithBadLabels)
 	_, err = client.AppsV1().Deployments("test-ns").Create(&deploymentWithIgnoreLabels)

--- a/admiral/pkg/controller/admiral/pod.go
+++ b/admiral/pkg/controller/admiral/pod.go
@@ -104,7 +104,7 @@ func (d *PodController) GetPods() ([]*k8sV1.Pod, error) {
 	for _, v := range istioEnabledNs.Items {
 
 		pods := d.K8sClient.CoreV1().Pods(v.Name)
-		admiralEnabledLabelFilter := d.labelSet.DeploymentLabel+"=true"
+		admiralEnabledLabelFilter := d.labelSet.DeploymentAnnotation +"=true"
 		podsList, err := pods.List(meta_v1.ListOptions{LabelSelector: admiralEnabledLabelFilter})
 
 		if err != nil {
@@ -156,7 +156,7 @@ func NewPodController(stopCh <-chan struct{}, handler PodHandler, config *rest.C
 func (d *PodController) Added(ojb interface{}) {
 	pod := ojb.(*k8sV1.Pod)
 	key := d.Cache.getKey(pod)
-	if len(key) > 0 && pod.Labels[d.labelSet.DeploymentLabel] == "true" {
+	if len(key) > 0 && pod.Labels[d.labelSet.DeploymentAnnotation] == "true" {
 		d.Cache.AppendPodToCluster(key, pod)
 		d.PodHandler.Added(pod)
 	}

--- a/admiral/pkg/controller/common/types.go
+++ b/admiral/pkg/controller/common/types.go
@@ -21,10 +21,11 @@ type ServiceEntryAddressStore struct {
 }
 
 type LabelSet struct {
-	DeploymentLabel string
-	TargetGroupLabel string
-	NamespaceSidecarInjectionLabel string
+	DeploymentLabel                     string
+	SubsetLabel                         string
+	NamespaceSidecarInjectionLabel      string
 	NamespaceSidecarInjectionLabelValue string
+	AdmiralIgnoreLabel string
 }
 
 func NewMap() *Map {

--- a/admiral/pkg/controller/common/types.go
+++ b/admiral/pkg/controller/common/types.go
@@ -20,6 +20,13 @@ type ServiceEntryAddressStore struct {
 	Addresses		[]string   `yaml:"addresses,omitempty"` //trading space for efficiency - this will give a quick way to validate that the address is unique
 }
 
+type LabelSet struct {
+	DeploymentLabel string
+	TargetGroupLabel string
+	NamespaceSidecarInjectionLabel string
+	NamespaceSidecarInjectionLabelValue string
+}
+
 func NewMap() *Map {
   n := new(Map)
   n.cache = make(map[string]string)

--- a/admiral/pkg/controller/common/types.go
+++ b/admiral/pkg/controller/common/types.go
@@ -21,11 +21,11 @@ type ServiceEntryAddressStore struct {
 }
 
 type LabelSet struct {
-	DeploymentLabel                     string
+	DeploymentAnnotation                string
 	SubsetLabel                         string
 	NamespaceSidecarInjectionLabel      string
 	NamespaceSidecarInjectionLabelValue string
-	AdmiralIgnoreLabel string
+	AdmiralIgnoreLabel                  string
 }
 
 func NewMap() *Map {

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20191002201903-404acd9df4cc // indirect
 	github.com/golang/protobuf v1.2.0
 	github.com/google/btree v1.0.0 // indirect
+	github.com/google/go-cmp v0.2.0
 	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf // indirect
 	github.com/googleapis/gnostic v0.2.0 // indirect
 	github.com/gorilla/mux v1.7.0 // indirect

--- a/install/sample/base/greeting.yaml
+++ b/install/sample/base/greeting.yaml
@@ -45,7 +45,7 @@ spec:
       labels:
         app: greeting
         identity: greeting
-        istio-injected: "true"
+        sidecar.istio.io/inject: "true"
     spec:
       containers:
         - name: greeting

--- a/install/sample/base/greeting.yaml
+++ b/install/sample/base/greeting.yaml
@@ -42,10 +42,11 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
       labels:
         app: greeting
-        identity: greeting
-        sidecar.istio.io/inject: "true"
+        identity: greetin
     spec:
       containers:
         - name: greeting

--- a/install/sample/base/webapp.yaml
+++ b/install/sample/base/webapp.yaml
@@ -17,7 +17,6 @@ spec:
       labels:
         app: webapp
         identity: webapp
-        sidecar.istio.io/inject: "true"
         #admiral-ignore: "true" #Uncommenting this line will cause admiral to ignore this deployment despite the fact that it's in the mesh
     spec:
       serviceAccountName: webapp

--- a/install/sample/base/webapp.yaml
+++ b/install/sample/base/webapp.yaml
@@ -17,7 +17,8 @@ spec:
       labels:
         app: webapp
         identity: webapp
-        istio-injected: "true"
+        sidecar.istio.io/inject: "true"
+        #admiral-ignore: "true" #Uncommenting this line will cause admiral to ignore this deployment despite the fact that it's in the mesh
     spec:
       serviceAccountName: webapp
       containers:


### PR DESCRIPTION
Also added a target group label to the setup that can eventually be used to route traffic between deployments based on an arbitrary label 

Signed-off-by: Joe Peacock <joe_peacock@intuit.com>