### PR TITLE
Allow overriding some values to for development and debugging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,21 @@
-DOCKER_REPO=admiralproj
-IMAGE=$(DOCKER_REPO)/admiral
-DOCKER_USER=aattuluri
+DOCKER_REPO?=admiralproj
+IMAGE?=$(DOCKER_REPO)/admiral
+DOCKER_USER?=aattuluri
+
+DOCKERFILE?=Dockerfile.admiral
 
 SHELL := /bin/bash
 # Go parameters
-GOCMD=go
-GOBUILD=$(GOCMD) build
-GOCLEAN=$(GOCMD) clean
-GOTEST=$(GOCMD) test
-GOGET=$(GOCMD) get
-GOBIN=$(GOPATH)/bin
-OUT=./out/
+GOCMD?=go
+GOBUILD?=$(GOCMD) build
+GOCLEAN?=$(GOCMD) clean
+GOTEST?=$(GOCMD) test
+GOGET?=$(GOCMD) get
+GOBIN?=$(GOPATH)/bin
+OUT?=./out/
 
-BINARY_NAME=$(OUT)admiral
-BINARY_DARWIN=$(BINARY_NAME)_darwin
+BINARY_NAME?=$(OUT)admiral
+BINARY_DARWIN?=$(BINARY_NAME)_darwin
 
 #Protoc
 PROTOC_VER=3.9.1
@@ -92,7 +94,7 @@ endif
 
 docker-build: set-tag
     #NOTE: Assumes binary has already been built (admiral)
-	docker build -t $(IMAGE):$(TAG) -f ./admiral/docker/Dockerfile.admiral .
+	docker build -t $(IMAGE):$(TAG) -f ./admiral/docker/$(DOCKERFILE) .
 
 docker-publish:
 ifndef DO_NOT_PUBLISH
@@ -125,7 +127,7 @@ download-kustomize:
 	mv kustomize_kustomize.*_$(OPSYS)_amd64 kustomize
 	chmod u+x kustomize
 
-gen-yaml: 
+gen-yaml:
 	mkdir -p ./out/yaml
 	mkdir -p ./out/scripts
 	kustomize build ./install/admiral/overlays/demosinglecluster/ > ./out/yaml/demosinglecluster.yaml


### PR DESCRIPTION
Some of these would likely need to be overridden if one wanted to have an in-house build or do local development in a cluster.

In my development env I use KinD to spin up several clusters as a sandbox. This makes that a lot easier for me because I can 

1. set `imagePullPolicy: always` on the admiral deployment and set the image to a repo I control
2. build an image with dlv, to which I can attach a debugger and push it to a remote repo

After build and push, I force the deployment to roll a new replica by changing an annotation:

```bash
#!/bin/bash

set -ex

DOCKER_REPO=myrepo \
DOCKER_USER=myuser \
DOCKER_PASS=mypass \
make \
  build-linux \
  docker-build \
  docker-publish
# Force the deployment to roll new replicas
kubectl patch -n admiral deployment admiral -p '{"spec": {"template": {"metadata": {"annotations": {"v": "'$(cat /dev/urandom | env LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)'"}}}}}'
```

I find this is a straightforward setup to debug things and think this change is pretty simple and improves quality of life