### PR TITLE
Allow use of externalIPs for envs without LBs

### DIFF
--- a/admiral/pkg/controller/admiral/deployment.go
+++ b/admiral/pkg/controller/admiral/deployment.go
@@ -33,7 +33,7 @@ type DeploymentController struct {
 	Cache             *deploymentCache
 	informer          cache.SharedIndexInformer
 	ctl               *Controller
-	labelSet 		  *common.LabelSet
+	labelSet          *common.LabelSet
 }
 
 type deploymentCache struct {
@@ -80,7 +80,7 @@ func (d *DeploymentController) GetDeployments() ([]*k8sAppsV1.Deployment, error)
 
 	ns := d.K8sClient.CoreV1().Namespaces()
 
-	namespaceSidecarInjectionLabelFilter := d.labelSet.NamespaceSidecarInjectionLabel+"="+d.labelSet.NamespaceSidecarInjectionLabelValue
+	namespaceSidecarInjectionLabelFilter := d.labelSet.NamespaceSidecarInjectionLabel + "=" + d.labelSet.NamespaceSidecarInjectionLabelValue
 	istioEnabledNs, err := ns.List(meta_v1.ListOptions{LabelSelector: namespaceSidecarInjectionLabelFilter})
 
 	if err != nil {
@@ -145,11 +145,11 @@ func NewDeploymentController(stopCh <-chan struct{}, handler DeploymentHandler, 
 	return &deploymentController, nil
 }
 
-func NewDeploymentControllerWithLabelOverride(stopCh <-chan struct{}, handler DeploymentHandler, config *rest.Config, resyncPeriod time.Duration,labelSet *common.LabelSet) (*DeploymentController, error) {
+func NewDeploymentControllerWithLabelOverride(stopCh <-chan struct{}, handler DeploymentHandler, config *rest.Config, resyncPeriod time.Duration, labelSet *common.LabelSet) (*DeploymentController, error) {
 
-	dc, err :=  NewDeploymentController(stopCh,handler,config,resyncPeriod)
-	dc.labelSet =labelSet
-	return dc,err
+	dc, err := NewDeploymentController(stopCh, handler, config, resyncPeriod)
+	dc.labelSet = labelSet
+	return dc, err
 }
 
 func (d *DeploymentController) Added(obj interface{}) {
@@ -163,9 +163,13 @@ func (d *DeploymentController) Updated(obj interface{}, oldObj interface{}) {
 func HandleAddUpdateDeployment(ojb interface{}, d *DeploymentController) {
 	deployment := ojb.(*k8sAppsV1.Deployment)
 	key := d.Cache.getKey(deployment)
-	if len(key) > 0 && !d.shouldIgnoreBasedOnLabels(deployment) {
-		d.Cache.AppendDeploymentToCluster(key, deployment)
-		d.DeploymentHandler.Added(deployment)
+	if len(key) > 0 {
+		if !d.shouldIgnoreBasedOnLabels(deployment) {
+			d.Cache.AppendDeploymentToCluster(key, deployment)
+			d.DeploymentHandler.Added(deployment)
+		} else {
+			log.Debugf("ignoring deployment %v based on labels", deployment.Name)
+		}
 	}
 }
 
@@ -214,4 +218,4 @@ func (d *DeploymentController) GetDeploymentByLabel(labelValue string, namespace
 	}
 
 	return matchedDeployments.Items
-	}
+}

--- a/admiral/pkg/controller/admiral/service_test.go
+++ b/admiral/pkg/controller/admiral/service_test.go
@@ -2,8 +2,10 @@ package admiral
 
 import (
 	"github.com/google/go-cmp/cmp"
+	"github.com/istio-ecosystem/admiral/admiral/pkg/controller/common"
 	"github.com/istio-ecosystem/admiral/admiral/pkg/test"
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/clientcmd"
 	"sync"
 	"testing"
@@ -80,45 +82,63 @@ func TestServiceCache_GetLoadBalancer(t *testing.T) {
 	service.Namespace = "ns"
 	service.Status = v1.ServiceStatus{}
 	service.Status.LoadBalancer = v1.LoadBalancerStatus{}
-	service.Status.LoadBalancer.Ingress = append(service.Status.LoadBalancer.Ingress, v1.LoadBalancerIngress{Hostname:"hostname.com"})
-	service.Labels = map[string]string{"app":"test-service"}
+	service.Status.LoadBalancer.Ingress = append(service.Status.LoadBalancer.Ingress, v1.LoadBalancerIngress{Hostname: "hostname.com"})
+	service.Labels = map[string]string{"app": "test-service"}
 
 	s2 := &v1.Service{}
 	s2.Name = "test-service-ip"
 	s2.Namespace = "ns"
 	s2.Status = v1.ServiceStatus{}
 	s2.Status.LoadBalancer = v1.LoadBalancerStatus{}
-	s2.Status.LoadBalancer.Ingress = append(s2.Status.LoadBalancer.Ingress, v1.LoadBalancerIngress{IP:"1.2.3.4"})
-	s2.Labels = map[string]string{"app":"test-service-ip"}
+	s2.Status.LoadBalancer.Ingress = append(s2.Status.LoadBalancer.Ingress, v1.LoadBalancerIngress{IP: "1.2.3.4"})
+	s2.Labels = map[string]string{"app": "test-service-ip"}
+
+	// The primary use case is to support ingress gateways for local development
+	externalIPService := &v1.Service{}
+	externalIPService.Name = "test-service-externalip"
+	externalIPService.Namespace = "ns"
+	externalIPService.Spec = v1.ServiceSpec{}
+	externalIPService.Spec.ExternalIPs = []string{"1.2.3.4"}
+	externalIPService.Spec.Ports = []v1.ServicePort{
+		{
+			"http",
+			v1.ProtocolTCP,
+			common.DefaultMtlsPort,
+			intstr.FromInt(80),
+			30800,
+		},
+	}
+	externalIPService.Labels = map[string]string{"app": "test-service-externalip"}
 
 	ignoreService := &v1.Service{}
 	ignoreService.Name = "test-service-ignored"
 	ignoreService.Namespace = "ns"
 	ignoreService.Status = v1.ServiceStatus{}
 	ignoreService.Status.LoadBalancer = v1.LoadBalancerStatus{}
-	ignoreService.Status.LoadBalancer.Ingress = append(service.Status.LoadBalancer.Ingress, v1.LoadBalancerIngress{Hostname:"hostname.com"})
+	ignoreService.Status.LoadBalancer.Ingress = append(service.Status.LoadBalancer.Ingress, v1.LoadBalancerIngress{Hostname: "hostname.com"})
 	ignoreService.Annotations = map[string]string{"admiral.io/ignore": "true"}
-	ignoreService.Labels = map[string]string{"app":"test-service-ignored"}
+	ignoreService.Labels = map[string]string{"app": "test-service-ignored"}
 
 	ignoreService2 := &v1.Service{}
 	ignoreService2.Name = "test-service-ignored-later"
 	ignoreService2.Namespace = "ns"
 	ignoreService2.Status = v1.ServiceStatus{}
 	ignoreService2.Status.LoadBalancer = v1.LoadBalancerStatus{}
-	ignoreService2.Status.LoadBalancer.Ingress = append(service.Status.LoadBalancer.Ingress, v1.LoadBalancerIngress{Hostname:"hostname.com"})
-	ignoreService2.Labels = map[string]string{"app":"test-service-ignored-later"}
+	ignoreService2.Status.LoadBalancer.Ingress = append(service.Status.LoadBalancer.Ingress, v1.LoadBalancerIngress{Hostname: "hostname.com"})
+	ignoreService2.Labels = map[string]string{"app": "test-service-ignored-later"}
 
 	ignoreService3 := &v1.Service{}
 	ignoreService3.Name = "test-service-unignored-later"
 	ignoreService3.Namespace = "ns"
 	ignoreService3.Status = v1.ServiceStatus{}
 	ignoreService3.Status.LoadBalancer = v1.LoadBalancerStatus{}
-	ignoreService3.Status.LoadBalancer.Ingress = append(service.Status.LoadBalancer.Ingress, v1.LoadBalancerIngress{Hostname:"hostname.com"})
+	ignoreService3.Status.LoadBalancer.Ingress = append(service.Status.LoadBalancer.Ingress, v1.LoadBalancerIngress{Hostname: "hostname.com"})
 	ignoreService3.Annotations = map[string]string{"admiral.io/ignore": "true"}
-	ignoreService3.Labels = map[string]string{"app":"test-service-unignored-later"}
+	ignoreService3.Labels = map[string]string{"app": "test-service-unignored-later"}
 
 	sc.Put(service)
 	sc.Put(s2)
+	sc.Put(externalIPService)
 	sc.Put(ignoreService)
 	sc.Put(ignoreService2)
 	sc.Put(ignoreService3)
@@ -129,65 +149,78 @@ func TestServiceCache_GetLoadBalancer(t *testing.T) {
 	sc.Put(ignoreService2) //Ensuring that if the ignore label is added to a service, it's no longer found
 	sc.Put(ignoreService3) //And ensuring that if the ignore label is removed from a service, it becomes found
 
-
 	testCases := []struct {
-		name string
-		cache *serviceCache
-		key string
-		ns string
+		name           string
+		cache          *serviceCache
+		key            string
+		ns             string
 		expectedReturn string
+		expectedPort   int
 	}{
 		{
-			name: "Find service load balancer when present",
-			cache: &sc,
-			key: "test-service",
-			ns: "ns",
+			name:           "Find service load balancer when present",
+			cache:          &sc,
+			key:            "test-service",
+			ns:             "ns",
 			expectedReturn: "hostname.com",
+			expectedPort:   common.DefaultMtlsPort,
 		},
 		{
-			name: "Return default when service not present",
-			cache: &sc,
-			key: "test-service",
-			ns: "ns-incorrect",
+			name:           "Return default when service not present",
+			cache:          &sc,
+			key:            "test-service",
+			ns:             "ns-incorrect",
 			expectedReturn: "admiral_dummy.com",
+			expectedPort:   0,
 		},
 		{
-			name: "Falls back to IP",
-			cache: &sc,
-			key: "test-service-ip",
-			ns: "ns",
+			name:           "Falls back to IP",
+			cache:          &sc,
+			key:            "test-service-ip",
+			ns:             "ns",
 			expectedReturn: "1.2.3.4",
+			expectedPort:   common.DefaultMtlsPort,
 		},
 		{
-			name: "Successfully ignores services with the ignore label",
-			cache: &sc,
-			key: "test-service-ignored",
-			ns: "ns",
+			name:           "Falls back to externalIP",
+			cache:          &sc,
+			key:            "test-service-externalip",
+			ns:             "ns",
+			expectedReturn: "1.2.3.4",
+			expectedPort:   30800,
+		},
+		{
+			name:           "Successfully ignores services with the ignore label",
+			cache:          &sc,
+			key:            "test-service-ignored",
+			ns:             "ns",
 			expectedReturn: "admiral_dummy.com",
+			expectedPort:   common.DefaultMtlsPort,
 		},
 		{
-			name: "Successfully ignores services when the ignore label is added after the service had been added to the cache for the first time",
-			cache: &sc,
-			key: "test-service-ignored-later",
-			ns: "ns",
+			name:           "Successfully ignores services when the ignore label is added after the service had been added to the cache for the first time",
+			cache:          &sc,
+			key:            "test-service-ignored-later",
+			ns:             "ns",
 			expectedReturn: "admiral_dummy.com",
+			expectedPort:   common.DefaultMtlsPort,
 		},
 		{
-			name: "Successfully finds services when the ignore label is added initially, then removed",
-			cache: &sc,
-			key: "test-service-unignored-later",
-			ns: "ns",
+			name:           "Successfully finds services when the ignore label is added initially, then removed",
+			cache:          &sc,
+			key:            "test-service-unignored-later",
+			ns:             "ns",
 			expectedReturn: "hostname.com",
+			expectedPort:   common.DefaultMtlsPort,
 		},
 	}
 
 	for _, c := range testCases {
 		t.Run(c.name, func(t *testing.T) {
-			loadBalancer := c.cache.GetLoadBalancer(c.key, c.ns)
-			if loadBalancer != c.expectedReturn {
-				t.Errorf("Unexpected load balancer returned. Got %v, expected %v", loadBalancer, c.expectedReturn)
+			loadBalancer, port := c.cache.GetLoadBalancer(c.key, c.ns)
+			if loadBalancer != c.expectedReturn || port != c.expectedPort {
+				t.Errorf("Unexpected load balancer returned. Got %v:%v, expected %v:%v", loadBalancer, port, c.expectedReturn, c.expectedPort)
 			}
 		})
 	}
 }
-


### PR DESCRIPTION
This allows use in environments which do not provide LoadBalancers by using the first externalIP from `service.spec.externalIPs`.