### PR TITLE
FQDN template

### DIFF
--- a/admiral/cmd/admiral/cmd/root.go
+++ b/admiral/cmd/admiral/cmd/root.go
@@ -57,6 +57,8 @@ func GetRootCmd(args []string) *cobra.Command {
 		fmt.Sprintf("Set log verbosity, defaults to 'Info'. Must be between %v and %v", int(log.PanicLevel), int(log.TraceLevel)))
 	rootCmd.PersistentFlags().StringVar(&params.KubeconfigPath, "kube_config", "",
 		"Use a Kubernetes configuration file instead of in-cluster configuration")
+	rootCmd.PersistentFlags().StringVar(&params.FQDNTemplate, "fqdn_template", "{{.Environment}}.{{.Identity}}.{{.Suffix}}",
+		"Use a custom FQDN template to generate global service names")
 	rootCmd.PersistentFlags().BoolVar(&params.ArgoRolloutsEnabled, "argo_rollouts", false,
 		"Use argo rollout configurations")
 	rootCmd.PersistentFlags().StringVar(&params.ClusterRegistriesNamespace, "secret_namespace", "admiral",

--- a/admiral/pkg/clusters/registry.go
+++ b/admiral/pkg/clusters/registry.go
@@ -8,6 +8,7 @@ import (
 	v12 "k8s.io/api/apps/v1"
 	"k8s.io/client-go/rest"
 	"sync"
+	"text/template"
 	"time"
 
 	argo "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
@@ -42,6 +43,11 @@ func InitAdmiral(ctx context.Context, params common.AdmiralParams) (*RemoteRegis
 		return nil, fmt.Errorf(" Error with dependency controller init: %v", err)
 	}
 
+	fqdnTmpl, err := template.New("fqdn").Parse(params.FQDNTemplate)
+	if err != nil {
+		return nil, fmt.Errorf(" Issue with FQDN template: %v", err)
+	}
+
 	w.remoteControllers = make(map[string]*RemoteController)
 
 	gtpCache := &globalTrafficCache{}
@@ -61,6 +67,7 @@ func InitAdmiral(ctx context.Context, params common.AdmiralParams) (*RemoteRegis
 		SubsetServiceEntryIdentityCache: &sync.Map{},
 		ServiceEntryAddressStore:        &ServiceEntryAddressStore{EntryAddresses: map[string]string{}, Addresses: []string{}},
 		GlobalTrafficCache:              gtpCache,
+		FQDNTemplate:                    fqdnTmpl,
 
 		argoRolloutsEnabled: params.ArgoRolloutsEnabled,
 	}

--- a/admiral/pkg/clusters/serviceentry.go
+++ b/admiral/pkg/clusters/serviceentry.go
@@ -7,7 +7,6 @@ import (
 	"math/rand"
 	"strconv"
 	"strings"
-	"text/template"
 	"time"
 
 	argo "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
@@ -44,7 +43,7 @@ func createServiceEntry(rc *RemoteController, admiralCache *AdmiralCache,
 	return tmpSe
 }
 
-func createServiceEntryForNewServiceOrPod(env string, sourceIdentity string, remoteRegistry *RemoteRegistry, fqdnTemplate *template.Template) map[string]*networking.ServiceEntry {
+func createServiceEntryForNewServiceOrPod(env string, sourceIdentity string, remoteRegistry *RemoteRegistry) map[string]*networking.ServiceEntry {
 	//create a service entry, destination rule and virtual service in the local cluster
 	sourceServices := make(map[string]*k8sV1.Service)
 
@@ -73,7 +72,7 @@ func createServiceEntryForNewServiceOrPod(env string, sourceIdentity string, rem
 				continue
 			}
 
-			cname = common.GetCname(deploymentInstance, common.GetWorkloadIdentifier(), common.GetHostnameSuffix(), fqdnTemplate)
+			cname = common.GetCname(deploymentInstance, common.GetWorkloadIdentifier(), common.GetHostnameSuffix(), remoteRegistry.AdmiralCache.FQDNTemplate)
 			sourceDeployments[rc.ClusterID] = deploymentInstance
 			createServiceEntry(rc, remoteRegistry.AdmiralCache, deploymentInstance, serviceEntries)
 		} else if rollout != nil && rollout.Rollouts[env] != nil {

--- a/admiral/pkg/clusters/serviceentry_test.go
+++ b/admiral/pkg/clusters/serviceentry_test.go
@@ -156,7 +156,6 @@ func TestCreateServiceEntryForNewServiceOrPod(t *testing.T) {
 
 	rr.remoteControllers["test.cluster"] = rc
 	createServiceEntryForNewServiceOrPod("test", "bar", rr)
-
 }
 
 func TestGetLocalAddressForSe(t *testing.T) {

--- a/admiral/pkg/clusters/types.go
+++ b/admiral/pkg/clusters/types.go
@@ -393,7 +393,7 @@ func (pc *DeploymentHandler) Added(obj *k8sAppsV1.Deployment) {
 
 	env := common.GetEnv(obj)
 
-	createServiceEntryForNewServiceOrPod(env, globalIdentifier, pc.RemoteRegistry, pc.RemoteRegistry.AdmiralCache.FQDNTemplate)
+	createServiceEntryForNewServiceOrPod(env, globalIdentifier, pc.RemoteRegistry)
 }
 
 func (pc *DeploymentHandler) Deleted(obj *k8sAppsV1.Deployment) {
@@ -454,7 +454,7 @@ func (rh *RolloutHandler) Added(obj *argo.Rollout) {
 
 	env := common.GetEnvForRollout(obj)
 
-	createServiceEntryForNewServiceOrPod(env, globalIdentifier, rh.RemoteRegistry, rh.RemoteRegistry.AdmiralCache.FQDNTemplate)
+	createServiceEntryForNewServiceOrPod(env, globalIdentifier, rh.RemoteRegistry)
 }
 
 func (rh *RolloutHandler) Updated(obj *argo.Rollout) {

--- a/admiral/pkg/controller/common/types.go
+++ b/admiral/pkg/controller/common/types.go
@@ -43,6 +43,7 @@ type AdmiralParams struct {
 	HostnameSuffix             string
 	WorkloadSidecarUpdate      string
 	WorkloadSidecarName        string
+	FQDNTemplate               string
 }
 
 func (b AdmiralParams) String() string {


### PR DESCRIPTION
See https://istio.slack.com/archives/CT3F18T08/p1596656035039000 for context.

This PR adds an `--fqdn_template` flag, which can be used to configure arbitrary FQDN structure for services.

This works for me locally with `--fqdn_template "{{.Identity}}.{{.Deployment.ObjectMeta.Namespace}}.{{.Suffix}}"`. without that set I get the normal naming behavior

I see a few errors in the logs but I believe I get correct behavior from the app.

```
time="2020-08-06T05:29:37Z" level=error msg="op=%s type=%v name=%v cluster=%s message=%sserviceentries.networking.istio.io \"httpbin.bar.global-se\" not found"
time="2020-08-06T05:29:37Z" level=info msg="op=Add type=ServiceEntry name=httpbin.bar.global-se cluster=kind-istio-mc-demo-1, e=Success"
time="2020-08-06T05:29:37Z" level=info msg="op=Add type=DestinationRule name=httpbin.bar.global-default-dr cluster=kind-istio-mc-demo-1, e=Success"
time="2020-08-06T05:29:37Z" level=info msg="op=Event type=DestinationRule name=httpbin.bar.global-default-dr cluster=kind-istio-mc-demo-1 message=Skipping the namespace: admiral-sync"
time="2020-08-06T05:29:37Z" level=info msg="op=Event type=VirtualService name=httpbin.bar.global-default-vs cluster=kind-istio-mc-demo-1 message=Received event"
time="2020-08-06T05:29:37Z" level=info msg="op=Event type=VirtualService name=httpbin.bar.global-default-vs cluster=kind-istio-mc-demo-1 message=Skipping the namespace: admiral-sync"
time="2020-08-06T05:29:37Z" level=info msg="op=Add type=VirtualService name=httpbin.bar.global-default-vs cluster=kind-istio-mc-demo-1, e=Success"
time="2020-08-06T05:29:37Z" level=info msg="op=GetMeshPorts type=service name=httpbin cluster=kind-istio-mc-demo-2 message=No mesh ports present, defaulting to first port"
time="2020-08-06T05:29:37Z" level=error msg="op=%s type=%v name=%v cluster=%s message=%sserviceentries.networking.istio.io \"httpbin.bar.global-se\" not found"
time="2020-08-06T05:29:37Z" level=info msg="op=Add type=ServiceEntry name=httpbin.bar.global-se cluster=kind-istio-mc-demo-2, e=Success"
time="2020-08-06T05:29:37Z" level=info msg="op=Event type=DestinationRule name=httpbin.bar.global-default-dr cluster=kind-istio-mc-demo-2 message=Skipping the namespace: admiral-sync"
time="2020-08-06T05:29:37Z" level=info msg="op=Add type=DestinationRule name=httpbin.bar.global-default-dr cluster=kind-istio-mc-demo-2, e=Success"
time="2020-08-06T05:29:37Z" level=info msg="op=Add type=VirtualService name=httpbin.bar.global-default-vs cluster=kind-istio-mc-demo-2, e=Success"
time="2020-08-06T05:29:37Z" level=info msg="op=Event type=VirtualService name=httpbin.bar.global-default-vs cluster=kind-istio-mc-demo-2 message=Received event"
time="2020-08-06T05:29:37Z" level=info msg="op=Event type=VirtualService name=httpbin.bar.global-default-vs cluster=kind-istio-mc-demo-2 message=Skipping the namespace: admiral-sync"
time="2020-08-06T05:29:39Z" level=info msg="Successfully updated service entry cache state"
time="2020-08-06T05:29:39Z" level=info msg="op=GetMeshPorts type=service name=httpbin cluster=kind-istio-mc-demo-1 message=No mesh ports present, defaulting to first port"
time="2020-08-06T05:29:39Z" level=info msg="op=Update type=ServiceEntry name=httpbin.bar.global-se cluster=kind-istio-mc-demo-1, e=Success"
time="2020-08-06T05:29:39Z" level=info msg="op=Update type=DestinationRule name=httpbin.bar.global-default-dr cluster=kind-istio-mc-demo-1, e=Success"
time="2020-08-06T05:29:39Z" level=info msg="op=Update type=VirtualService name=httpbin.bar.global-default-vs cluster=kind-istio-mc-demo-1, e=Success"
time="2020-08-06T05:29:58Z" level=info msg="op=Event type=deployment name=httpbin cluster= message=Received"
time="2020-08-06T05:29:58Z" level=info msg="op=GetMeshPorts type=service name=httpbin cluster=kind-istio-mc-demo-1 message=No mesh ports present, defaulting to first port"
time="2020-08-06T05:29:58Z" level=info msg="op=GetMeshPorts type=service name=httpbin cluster=kind-istio-mc-demo-2 message=No mesh ports present, defaulting to first port"
time="2020-08-06T05:30:05Z" level=info msg="op=GetMeshPorts type=service name=httpbin cluster=kind-istio-mc-demo-1 message=No mesh ports present, defaulting to first port"
time="2020-08-06T05:30:05Z" level=info msg="op=Update type=ServiceEntry name=httpbin.bar.global-se cluster=kind-istio-mc-demo-1, e=Success"
time="2020-08-06T05:30:05Z" level=info msg="op=Update type=DestinationRule name=httpbin.bar.global-default-dr cluster=kind-istio-mc-demo-1, e=Success"
time="2020-08-06T05:30:05Z" level=info msg="op=Update type=VirtualService name=httpbin.bar.global-default-vs cluster=kind-istio-mc-demo-1, e=Success"
time="2020-08-06T05:30:05Z" level=info msg="op=GetMeshPorts type=service name=httpbin cluster=kind-istio-mc-demo-2 message=No mesh ports present, defaulting to first port"
time="2020-08-06T05:30:05Z" level=info msg="op=Update type=ServiceEntry name=httpbin.bar.global-se cluster=kind-istio-mc-demo-2, e=Success"
time="2020-08-06T05:30:05Z" level=info msg="op=Update type=DestinationRule name=httpbin.bar.global-default-dr cluster=kind-istio-mc-demo-2, e=Success"
time="2020-08-06T05:30:05Z" level=info msg="op=Update type=VirtualService name=httpbin.bar.global-default-vs cluster=kind-istio-mc-demo-2, e=Success"
time="2020-08-06T05:31:30Z" level=info msg="op=Event type=VirtualService name=httpbin.bar.global-default-vs cluster=kind-istio-mc-demo-1 message=Received event"
time="2020-08-06T05:31:30Z" level=info msg="op=Event type=VirtualService name=httpbin.bar.global-default-vs cluster=kind-istio-mc-demo-1 message=Skipping the namespace: admiral-sync"
time="2020-08-06T05:31:30Z" level=info msg="Skipping event: DestinationRule from cluster kind-istio-mc-demo-1 for {*.global tls:<mode:ISTIO_MUTUAL >  [] [] {} [] 0}"
time="2020-08-06T05:31:30Z" level=info msg="op=Event type=DestinationRule name=istio-multicluster-ingressgateway cluster=kind-istio-mc-demo-1 message=No dependent clusters found"
time="2020-08-06T05:31:30Z" level=info msg="op=Event type=DestinationRule name=httpbin.bar.global-default-dr cluster=kind-istio-mc-demo-1 message=Skipping the namespace: admiral-sync"
time="2020-08-06T05:31:30Z" level=info msg="op=Event type=deployment name=httpbin cluster= message=Received"
time="2020-08-06T05:31:30Z" level=info msg="op=GetMeshPorts type=service name=httpbin cluster=kind-istio-mc-demo-1 message=No mesh ports present, defaulting to first port"
time="2020-08-06T05:31:31Z" level=info msg="op=Event type=VirtualService name=httpbin.bar.global-default-vs cluster=kind-istio-mc-demo-2 message=Received event"
time="2020-08-06T05:31:31Z" level=info msg="op=Event type=VirtualService name=httpbin.bar.global-default-vs cluster=kind-istio-mc-demo-2 message=Skipping the namespace: admiral-sync"
time="2020-08-06T05:31:31Z" level=info msg="Skipping event: DestinationRule from cluster kind-istio-mc-demo-2 for {*.global tls:<mode:ISTIO_MUTUAL >  [] [] {} [] 0}"
time="2020-08-06T05:31:31Z" level=info msg="op=Event type=DestinationRule name=istio-multicluster-ingressgateway cluster=kind-istio-mc-demo-2 message=No dependent clusters found"
time="2020-08-06T05:31:31Z" level=info msg="op=Event type=DestinationRule name=httpbin.bar.global-default-dr cluster=kind-istio-mc-demo-2 message=Skipping the namespace: admiral-sync"
time="2020-08-06T05:31:31Z" level=info msg="op=Event type=deployment name=httpbin cluster= message=Received"
time="2020-08-06T05:31:31Z" level=info msg="op=GetMeshPorts type=service name=httpbin cluster=kind-istio-mc-demo-1 message=No mesh ports present, defaulting to first port"
time="2020-08-06T05:31:31Z" level=info msg="op=GetMeshPorts type=service name=httpbin cluster=kind-istio-mc-demo-2 message=No mesh ports present, defaulting to first port"
time="2020-08-06T05:31:32Z" level=info msg="op=GetMeshPorts type=service name=httpbin cluster=kind-istio-mc-demo-2 message=No mesh ports present, defaulting to first port"
time="2020-08-06T05:31:37Z" level=info msg="op=GetMeshPorts type=service name=httpbin cluster=kind-istio-mc-demo-2 message=No mesh ports present, defaulting to first port"
time="2020-08-06T05:31:37Z" level=info msg="op=Update type=ServiceEntry name=httpbin.bar.global-se cluster=kind-istio-mc-demo-2, e=Success"
time="2020-08-06T05:31:37Z" level=info msg="op=Update type=DestinationRule name=httpbin.bar.global-default-dr cluster=kind-istio-mc-demo-2, e=Success"
time="2020-08-06T05:31:37Z" level=info msg="op=Update type=VirtualService name=httpbin.bar.global-default-vs cluster=kind-istio-mc-demo-2, e=Success"
time="2020-08-06T05:31:37Z" level=info msg="op=GetMeshPorts type=service name=httpbin cluster=kind-istio-mc-demo-1 message=No mesh ports present, defaulting to first port"
time="2020-08-06T05:31:37Z" level=info msg="op=Update type=ServiceEntry name=httpbin.bar.global-se cluster=kind-istio-mc-demo-1, e=Success"
time="2020-08-06T05:31:37Z" level=info msg="op=Update type=DestinationRule name=httpbin.bar.global-default-dr cluster=kind-istio-mc-demo-1, e=Success"
time="2020-08-06T05:31:37Z" level=info msg="op=Update type=VirtualService name=httpbin.bar.global-default-vs cluster=kind-istio-mc-demo-1, e=Success"
time="2020-08-06T05:31:39Z" level=info msg="op=GetMeshPorts type=service name=httpbin cluster=kind-istio-mc-demo-1 message=No mesh ports present, defaulting to first port"
time="2020-08-06T05:31:39Z" level=info msg="op=Update type=ServiceEntry name=httpbin.bar.global-se cluster=kind-istio-mc-demo-1, e=Success"
time="2020-08-06T05:31:39Z" level=info msg="op=Update type=DestinationRule name=httpbin.bar.global-default-dr cluster=kind-istio-mc-demo-1, e=Success"
time="2020-08-06T05:31:39Z" level=info msg="op=Update type=VirtualService name=httpbin.bar.global-default-vs cluster=kind-istio-mc-demo-1, e=Success"
time="2020-08-06T05:31:39Z" level=info msg="op=GetMeshPorts type=service name=httpbin cluster=kind-istio-mc-demo-2 message=No mesh ports present, defaulting to first port"
time="2020-08-06T05:31:39Z" level=info msg="op=Update type=ServiceEntry name=httpbin.bar.global-se cluster=kind-istio-mc-demo-2, e=Success"
time="2020-08-06T05:31:39Z" level=info msg="op=Update type=DestinationRule name=httpbin.bar.global-default-dr cluster=kind-istio-mc-demo-2, e=Success"
time="2020-08-06T05:31:39Z" level=info msg="op=Update type=VirtualService name=httpbin.bar.global-default-vs cluster=kind-istio-mc-demo-2, e=Success"
```