### PR TITLE
Update link to setting up DNS for .global domains

### DIFF
--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -5,7 +5,7 @@
 
 * One or more k8s clusters with version 1.13 or above
 * [Install istio control plane](https://istio.io/docs/setup/install/multicluster/gateways/#deploy-the-istio-control-plane-in-each-cluster) on each of these k8s clusters
-* [Configure DNS redirect](https://istio.io/docs/setup/install/multicluster/gateways/#setup-dns) for entries ending in `global`
+* [Configure DNS redirect](https://istio.io/v1.7/docs/setup/install/multicluster/gateways/#setup-dns) for entries ending in `global`
 * Remove envoy cluster rewrite filter
 Delete Istio's envoy filter for translating `global` to `svc.cluster.local` at istio-ingressgateway because we don't need that as Admiral generates Service Entries for cross cluster communication to just work!
 ```


### PR DESCRIPTION
## Goal
Use link from istio 1.7 for configuring DNS for `.global` domains.

_The previous link was removed from the latest release in istio 1.8._
