### PR TITLE
Fix CircleCI build and Golang linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ jobs:
       MINIKUBE_WANTREPORTERRORPROMPT: false
       MINIKUBE_HOME: /home/circleci
       CHANGE_MINIKUBE_NONE_USER: true
+    resource_class: large
     steps:
       - attach_workspace:
           at: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     working_directory: /go/pkg/mod/github.com/admiral
     docker:
-    - image: circleci/golang:1.11
+    - image: circleci/golang:1.16
     steps:
     - checkout
     - run:
@@ -104,7 +104,7 @@ jobs:
             ./run.sh "1.16.8" "1.7.6" "../out"
   publish-github-release:
     docker:
-    - image: circleci/golang:1.11
+    - image: circleci/golang:1.16
     working_directory: /go/pkg/mod/github.com/admiral
     steps:
     - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,6 @@ jobs:
       MINIKUBE_HOME: /home/circleci
       CHANGE_MINIKUBE_NONE_USER: true
     resource_class: large
-    parallelism: 2
     steps:
       - attach_workspace:
           at: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,7 @@ jobs:
       MINIKUBE_HOME: /home/circleci
       CHANGE_MINIKUBE_NONE_USER: true
     resource_class: large
+    parallelism: 2
     steps:
       - attach_workspace:
           at: .

--- a/.github/workflows/golang-ci-lint.yml
+++ b/.github/workflows/golang-ci-lint.yml
@@ -16,7 +16,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.29
+          version: latest
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.github/workflows/golang-ci-lint.yml
+++ b/.github/workflows/golang-ci-lint.yml
@@ -23,7 +23,6 @@ jobs:
 
           # Optional: golangci-lint command line arguments.
           args: >-
-            --out-format=github-actions
             --skip-dirs=admiral/pkg/client/clientset/versioned
             --tests=false
             --timeout=5m

--- a/admiral/pkg/apis/admiral/routes/handlers.go
+++ b/admiral/pkg/apis/admiral/routes/handlers.go
@@ -52,14 +52,16 @@ func (opts *RouteOpts) GetClusters(w http.ResponseWriter, r *http.Request) {
 	} else {
 		if len(clusterList) == 0 {
 			message := "No cluster is monitored by admiral"
-			log.Printf(message)
+			log.Println(message)
 			w.WriteHeader(200)
 			out, _ = json.Marshal(message)
-			w.Write(out)
 		} else {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(200)
-			w.Write(out)
+		}
+		_, err := w.Write(out)
+		if err != nil {
+			log.Println("Failed to write message: ", err)
 		}
 	}
 }
@@ -87,7 +89,11 @@ func (opts *RouteOpts) GetServiceEntriesByCluster(w http.ResponseWriter, r *http
 			if len(serviceEntriesByCluster) == 0 {
 				log.Printf("API call get service entry by cluster failed for clustername %v with Error: %v", clusterName, "No service entries configured for cluster - "+clusterName)
 				w.WriteHeader(200)
-				w.Write([]byte(fmt.Sprintf("No service entries configured for cluster - %s", clusterName)))
+				_, err := w.Write([]byte(fmt.Sprintf("No service entries configured for cluster - %s", clusterName)))
+				if err != nil {
+					log.Println("Error writing body: ", err)
+				}
+
 			} else {
 				response = serviceEntriesByCluster
 				out, err := json.Marshal(response)

--- a/admiral/pkg/apis/admiral/routes/handlers.go
+++ b/admiral/pkg/apis/admiral/routes/handlers.go
@@ -103,7 +103,10 @@ func (opts *RouteOpts) GetServiceEntriesByCluster(w http.ResponseWriter, r *http
 				} else {
 					w.Header().Set("Content-Type", "application/json")
 					w.WriteHeader(200)
-					w.Write(out)
+					_, err := w.Write(out)
+					if err != nil {
+						log.Println("failed to write resp body: ", err)
+					}
 				}
 			}
 		}
@@ -140,7 +143,10 @@ func (opts *RouteOpts) GetServiceEntriesByIdentity(w http.ResponseWriter, r *htt
 		} else {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(200)
-			w.Write(out)
+			_, err := w.Write(out)
+			if err != nil {
+				log.Println("failed to write resp body", err)
+			}
 		}
 	} else {
 		log.Printf("Identity not provided as part of the request")

--- a/admiral/pkg/apis/admiral/server/server.go
+++ b/admiral/pkg/apis/admiral/server/server.go
@@ -53,8 +53,6 @@ func (s *Service) Start(ctx context.Context, port int, routes Routes, filter []F
 	log.Printf("Starting admiral api server on port=%d", port)
 	log.Fatalln(s.server.ListenAndServe())
 
-	return
-
 }
 
 func (s *Service) newRouter(routes Routes, filter []Filter) *mux.Router {
@@ -86,13 +84,21 @@ func (s *Service) newRouter(routes Routes, filter []Filter) *mux.Router {
 }
 
 func waitForStop(s *Service) {
-	for {
-		select {
-		case <-s.ctx.Done():
-			log.Println("context done stopping server")
-			s.stop()
-			return
+	//for {
+	//	select {
+	//	case <-s.ctx.Done():
+	//		log.Println("context done stopping server")
+	//		s.stop()
+	//		return
+	//	}
+	//}
+	for range s.ctx.Done() {
+		log.Println("context done stopping server")
+		err := s.stop()
+		if err != nil {
+			log.Println("error stopping server: ", err)
 		}
+		return
 	}
 }
 

--- a/admiral/pkg/apis/admiral/server/server.go
+++ b/admiral/pkg/apis/admiral/server/server.go
@@ -98,7 +98,6 @@ func waitForStop(s *Service) {
 		if err != nil {
 			log.Println("error stopping server: ", err)
 		}
-		return
 	}
 }
 

--- a/tests/create_cluster.sh
+++ b/tests/create_cluster.sh
@@ -5,7 +5,7 @@
 k8s_version=$1
 
 if [[ $IS_LOCAL == "false" ]]; then
-  sudo -E minikube start --vm-driver=none --cpus 4 --memory 4096 --kubernetes-version=$k8s_version &> $HOME/minikube.log 2>&1 < /dev/null
+  sudo -E minikube start --vm-driver=none --cpus 6 --memory 6144 --kubernetes-version=$k8s_version &> $HOME/minikube.log 2>&1 < /dev/null
 else
   minikube start --memory=4096 --cpus=4 --kubernetes-version=$k8s_version --vm-driver "virtualbox"
   #label node for locality load balancing


### PR DESCRIPTION
CI builds are failing due to the certificate change shown [here](https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/). Updating to the latest image from Circle CI fixes this problem and allows Admiral to build again as expected. 

Fixed linter to run though  did not make changes to any current files to limit this to just fixing CI and not lint issues. 