### PR TITLE
fix: weighted services for source

### DIFF
--- a/admiral/pkg/clusters/serviceentry.go
+++ b/admiral/pkg/clusters/serviceentry.go
@@ -169,10 +169,10 @@ func modifyServiceEntryForNewServiceOrPod(event admiral.EventType, env string, s
 						ep.Address = clusterIngress
 						ep.Ports = oldPorts
 						// see if we have weighted services (rollouts with canary strategy)
-					} else if len(weightedServices) > 1 {
+					} else if len(sourceWeightedServices[sourceCluster]) > 1 {
 						//add one endpoint per each service, may be modify
 						var se = copyServiceEntry(serviceEntry)
-						updateEndpointsForWeightedServices(se, weightedServices, clusterIngress, meshPorts)
+						updateEndpointsForWeightedServices(se, sourceWeightedServices[sourceCluster], clusterIngress, meshPorts)
 						AddServiceEntriesWithDr(remoteRegistry.AdmiralCache, map[string]string{sourceCluster: sourceCluster}, remoteRegistry.RemoteControllers,
 							map[string]*networking.ServiceEntry{key: se})
 					} else {

--- a/admiral/pkg/clusters/serviceentry.go
+++ b/admiral/pkg/clusters/serviceentry.go
@@ -59,6 +59,7 @@ func modifyServiceEntryForNewServiceOrPod(event admiral.EventType, env string, s
 
 	//create a service entry, destination rule and virtual service in the local cluster
 	sourceServices := make(map[string]*k8sV1.Service)
+	sourceWeightedServices := make(map[string]map[string]*WeightedService)
 	sourceDeployments := make(map[string]*k8sAppsV1.Deployment)
 	sourceRollouts := make(map[string]*argo.Rollout)
 
@@ -120,6 +121,7 @@ func modifyServiceEntryForNewServiceOrPod(event admiral.EventType, env string, s
 		remoteRegistry.AdmiralCache.CnameClusterCache.Put(cname, rc.ClusterID, rc.ClusterID)
 		remoteRegistry.AdmiralCache.CnameIdentityCache.Store(cname, sourceIdentity)
 		sourceServices[rc.ClusterID] = serviceInstance
+		sourceWeightedServices[rc.ClusterID] = weightedServices
 	}
 
 	util.LogElapsedTimeSince("BuildServiceEntry", sourceIdentity, env, "", start)
@@ -159,7 +161,7 @@ func modifyServiceEntryForNewServiceOrPod(event admiral.EventType, env string, s
 					// Update endpoints with locafqdn for active and preview se of bluegreen rollout
 					if isBlueGreenStrategy {
 						oldPorts := ep.Ports
-						updateEndpointsForBlueGreen(sourceRollouts[sourceCluster], weightedServices, cnames, ep, sourceCluster, key)
+						updateEndpointsForBlueGreen(sourceRollouts[sourceCluster], sourceWeightedServices[sourceCluster], cnames, ep, sourceCluster, key)
 
 						AddServiceEntriesWithDr(remoteRegistry.AdmiralCache, map[string]string{sourceCluster: sourceCluster}, remoteRegistry.RemoteControllers,
 							map[string]*networking.ServiceEntry{key: serviceEntry})


### PR DESCRIPTION
`weightedServices` was initialized with K8s services without the source cluster context, which results in wrong weightedServices being used when the service existed in multiple cluster. 

The PR fixes the issue by initializing `sourceWeightedServices` with source cluster as key and use it for endpoint's local FQDN.