### PR TITLE
Fix Admiral install in the Examples document

### DIFF
--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -71,7 +71,7 @@ $ADMIRAL_HOME/scripts/cluster-secret.sh $MAIN_CLUSTER $MAIN_CLUSTER admiral
 4\. Install/Run Admiral-Sync in the remote clusters that admiral monitors
 ```
 # Create admiral role and bindings on remote cluster
-kubectl apply --context=$REMOTE_CLUSTER -f $ADMIRAL_HOME/yaml/remotecluster.yaml
+kubectl apply --kubeconfig=$REMOTE_CLUSTER -f $ADMIRAL_HOME/yaml/remotecluster.yaml
 ```
 5\. Add Remote Cluster to Admiral's watcher
 ```


### PR DESCRIPTION
This PR fixes a think-o in the installations steps:
- Step1: set the `REMOTE_CLUSTER` env variable as `REMOTE_CLUSTER=<path_to_kubeconfig_for_remote_cluster>`.  
- Step 4: use `REMOTE_CLUSTER` as a context.