### PR TITLE
Add default connection pool parameters for generated cnames

### DIFF
--- a/admiral/pkg/clusters/handler.go
+++ b/admiral/pkg/clusters/handler.go
@@ -32,6 +32,8 @@ const (
 	DefaultBaseEjectionTime         int64  = 300
 	DefaultConsecutiveGatewayErrors uint32 = 50
 	DefaultInterval                 int64  = 60
+	DefaultHTTP2MaxRequest          int32  = 1000
+	DefaultMaxRequestsPerConnection int32  = 100
 )
 
 // ServiceEntryHandler responsible for handling Add/Update/Delete events for
@@ -85,7 +87,17 @@ func getDestinationRule(se *v1alpha32.ServiceEntry, locality string, gtpTrafficP
 		dr         = &v1alpha32.DestinationRule{}
 	)
 	dr.Host = se.Hosts[0]
-	dr.TrafficPolicy = &v1alpha32.TrafficPolicy{Tls: &v1alpha32.ClientTLSSettings{Mode: v1alpha32.ClientTLSSettings_ISTIO_MUTUAL}}
+	dr.TrafficPolicy = &v1alpha32.TrafficPolicy{
+		Tls: &v1alpha32.ClientTLSSettings{
+			Mode: v1alpha32.ClientTLSSettings_ISTIO_MUTUAL,
+		},
+		ConnectionPool: &v1alpha32.ConnectionPoolSettings{
+			Http: &v1alpha32.ConnectionPoolSettings_HTTPSettings{
+				Http2MaxRequests:         DefaultHTTP2MaxRequest,
+				MaxRequestsPerConnection: DefaultMaxRequestsPerConnection,
+			},
+		},
+	}
 
 	if len(locality) == 0 {
 		log.Warnf(LogErrFormat, "Process", "GlobalTrafficPolicy", dr.Host, "", "Skipping gtp processing, locality of the cluster nodes cannot be determined. Is this minikube?")

--- a/admiral/pkg/clusters/handler.go
+++ b/admiral/pkg/clusters/handler.go
@@ -97,6 +97,11 @@ func getDestinationRule(se *v1alpha32.ServiceEntry, locality string, gtpTrafficP
 				MaxRequestsPerConnection: DefaultMaxRequestsPerConnection,
 			},
 		},
+		LoadBalancer: &v1alpha32.LoadBalancerSettings{
+			LbPolicy: &v1alpha32.LoadBalancerSettings_Simple{
+				Simple: v1alpha32.LoadBalancerSettings_LEAST_REQUEST,
+			},
+		},
 	}
 
 	if len(locality) == 0 {
@@ -105,7 +110,7 @@ func getDestinationRule(se *v1alpha32.ServiceEntry, locality string, gtpTrafficP
 	}
 	if gtpTrafficPolicy != nil && processGtp {
 		var loadBalancerSettings = &v1alpha32.LoadBalancerSettings{
-			LbPolicy: &v1alpha32.LoadBalancerSettings_Simple{Simple: v1alpha32.LoadBalancerSettings_ROUND_ROBIN},
+			LbPolicy: &v1alpha32.LoadBalancerSettings_Simple{Simple: v1alpha32.LoadBalancerSettings_LEAST_REQUEST},
 		}
 
 		if len(gtpTrafficPolicy.Target) > 0 {

--- a/admiral/pkg/clusters/handler.go
+++ b/admiral/pkg/clusters/handler.go
@@ -32,7 +32,7 @@ const (
 	DefaultBaseEjectionTime         int64  = 300
 	DefaultConsecutiveGatewayErrors uint32 = 50
 	DefaultInterval                 int64  = 60
-	DefaultHTTP2MaxRequest          int32  = 1000
+	DefaultHTTP2MaxRequests          int32  = 1000
 	DefaultMaxRequestsPerConnection int32  = 100
 )
 

--- a/admiral/pkg/clusters/handler.go
+++ b/admiral/pkg/clusters/handler.go
@@ -32,7 +32,7 @@ const (
 	DefaultBaseEjectionTime         int64  = 300
 	DefaultConsecutiveGatewayErrors uint32 = 50
 	DefaultInterval                 int64  = 60
-	DefaultHTTP2MaxRequests          int32  = 1000
+	DefaultHTTP2MaxRequests         int32  = 1000
 	DefaultMaxRequestsPerConnection int32  = 100
 )
 
@@ -93,7 +93,7 @@ func getDestinationRule(se *v1alpha32.ServiceEntry, locality string, gtpTrafficP
 		},
 		ConnectionPool: &v1alpha32.ConnectionPoolSettings{
 			Http: &v1alpha32.ConnectionPoolSettings_HTTPSettings{
-				Http2MaxRequests:         DefaultHTTP2MaxRequest,
+				Http2MaxRequests:         DefaultHTTP2MaxRequests,
 				MaxRequestsPerConnection: DefaultMaxRequestsPerConnection,
 			},
 		},

--- a/admiral/pkg/clusters/handler_test.go
+++ b/admiral/pkg/clusters/handler_test.go
@@ -180,7 +180,18 @@ func TestGetDestinationRule(t *testing.T) {
 		Interval:                 &duration.Duration{Seconds: 60},
 		MaxEjectionPercent:       100,
 	}
-	mTLS := &v1alpha3.TrafficPolicy{Tls: &v1alpha3.ClientTLSSettings{Mode: v1alpha3.ClientTLSSettings_ISTIO_MUTUAL}, OutlierDetection: outlierDetection}
+	mTLS := &v1alpha3.TrafficPolicy{
+		Tls: &v1alpha3.ClientTLSSettings{
+			Mode: v1alpha3.ClientTLSSettings_ISTIO_MUTUAL,
+		},
+		OutlierDetection: outlierDetection,
+		ConnectionPool: &v1alpha3.ConnectionPoolSettings{
+			Http: &v1alpha3.ConnectionPoolSettings_HTTPSettings{
+				Http2MaxRequests:         DefaultHTTP2MaxRequest,
+				MaxRequestsPerConnection: DefaultMaxRequestsPerConnection,
+			},
+		},
+	}
 
 	se := &v1alpha3.ServiceEntry{Hosts: []string{"qa.myservice.global"}, Endpoints: []*v1alpha3.WorkloadEntry{
 		{Address: "east.com", Locality: "us-east-2"}, {Address: "west.com", Locality: "us-west-2"},
@@ -199,6 +210,12 @@ func TestGetDestinationRule(t *testing.T) {
 				LocalityLbSetting: &v1alpha3.LocalityLoadBalancerSetting{},
 			},
 			OutlierDetection: outlierDetection,
+			ConnectionPool: &v1alpha3.ConnectionPoolSettings{
+				Http: &v1alpha3.ConnectionPoolSettings_HTTPSettings{
+					Http2MaxRequests:         DefaultHTTP2MaxRequest,
+					MaxRequestsPerConnection: DefaultMaxRequestsPerConnection,
+				},
+			},
 		},
 	}
 
@@ -218,6 +235,12 @@ func TestGetDestinationRule(t *testing.T) {
 				},
 			},
 			OutlierDetection: outlierDetection,
+			ConnectionPool: &v1alpha3.ConnectionPoolSettings{
+				Http: &v1alpha3.ConnectionPoolSettings_HTTPSettings{
+					Http2MaxRequests:         DefaultHTTP2MaxRequest,
+					MaxRequestsPerConnection: DefaultMaxRequestsPerConnection,
+				},
+			},
 		},
 	}
 

--- a/admiral/pkg/clusters/handler_test.go
+++ b/admiral/pkg/clusters/handler_test.go
@@ -187,7 +187,7 @@ func TestGetDestinationRule(t *testing.T) {
 		OutlierDetection: outlierDetection,
 		ConnectionPool: &v1alpha3.ConnectionPoolSettings{
 			Http: &v1alpha3.ConnectionPoolSettings_HTTPSettings{
-				Http2MaxRequests:         DefaultHTTP2MaxRequest,
+				Http2MaxRequests:         DefaultHTTP2MaxRequests,
 				MaxRequestsPerConnection: DefaultMaxRequestsPerConnection,
 			},
 		},
@@ -212,7 +212,7 @@ func TestGetDestinationRule(t *testing.T) {
 			OutlierDetection: outlierDetection,
 			ConnectionPool: &v1alpha3.ConnectionPoolSettings{
 				Http: &v1alpha3.ConnectionPoolSettings_HTTPSettings{
-					Http2MaxRequests:         DefaultHTTP2MaxRequest,
+					Http2MaxRequests:         DefaultHTTP2MaxRequests,
 					MaxRequestsPerConnection: DefaultMaxRequestsPerConnection,
 				},
 			},
@@ -237,7 +237,7 @@ func TestGetDestinationRule(t *testing.T) {
 			OutlierDetection: outlierDetection,
 			ConnectionPool: &v1alpha3.ConnectionPoolSettings{
 				Http: &v1alpha3.ConnectionPoolSettings_HTTPSettings{
-					Http2MaxRequests:         DefaultHTTP2MaxRequest,
+					Http2MaxRequests:         DefaultHTTP2MaxRequests,
 					MaxRequestsPerConnection: DefaultMaxRequestsPerConnection,
 				},
 			},

--- a/admiral/pkg/clusters/handler_test.go
+++ b/admiral/pkg/clusters/handler_test.go
@@ -191,6 +191,11 @@ func TestGetDestinationRule(t *testing.T) {
 				MaxRequestsPerConnection: DefaultMaxRequestsPerConnection,
 			},
 		},
+		LoadBalancer: &v1alpha3.LoadBalancerSettings{
+			LbPolicy: &v1alpha3.LoadBalancerSettings_Simple{
+				Simple: v1alpha3.LoadBalancerSettings_LEAST_REQUEST,
+			},
+		},
 	}
 
 	se := &v1alpha3.ServiceEntry{Hosts: []string{"qa.myservice.global"}, Endpoints: []*v1alpha3.WorkloadEntry{
@@ -206,7 +211,7 @@ func TestGetDestinationRule(t *testing.T) {
 		TrafficPolicy: &v1alpha3.TrafficPolicy{
 			Tls: &v1alpha3.ClientTLSSettings{Mode: v1alpha3.ClientTLSSettings_ISTIO_MUTUAL},
 			LoadBalancer: &v1alpha3.LoadBalancerSettings{
-				LbPolicy:          &v1alpha3.LoadBalancerSettings_Simple{Simple: v1alpha3.LoadBalancerSettings_ROUND_ROBIN},
+				LbPolicy:          &v1alpha3.LoadBalancerSettings_Simple{Simple: v1alpha3.LoadBalancerSettings_LEAST_REQUEST},
 				LocalityLbSetting: &v1alpha3.LocalityLoadBalancerSetting{},
 			},
 			OutlierDetection: outlierDetection,
@@ -224,7 +229,7 @@ func TestGetDestinationRule(t *testing.T) {
 		TrafficPolicy: &v1alpha3.TrafficPolicy{
 			Tls: &v1alpha3.ClientTLSSettings{Mode: v1alpha3.ClientTLSSettings_ISTIO_MUTUAL},
 			LoadBalancer: &v1alpha3.LoadBalancerSettings{
-				LbPolicy: &v1alpha3.LoadBalancerSettings_Simple{Simple: v1alpha3.LoadBalancerSettings_ROUND_ROBIN},
+				LbPolicy: &v1alpha3.LoadBalancerSettings_Simple{Simple: v1alpha3.LoadBalancerSettings_LEAST_REQUEST},
 				LocalityLbSetting: &v1alpha3.LocalityLoadBalancerSetting{
 					Distribute: []*v1alpha3.LocalityLoadBalancerSetting_Distribute{
 						{


### PR DESCRIPTION
This change adds a default HTTP connection pool configuration to the DestinationRule