### PR TITLE
Updating kustomize version and adding apple silicon instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 out*
 *.tar.gz
 *.out
+istio-*
+.DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,8 @@ export KUBECONFIG=~/.kube/config
                                                                                                    
 Mac: `$ADMIRAL_HOME/tests/install_istio.sh 1.7.4 osx` 
 
+Mac (Apple Silicon): `$ADMIRAL_HOME/tests/install_istio.sh 1.7.4 osx-arm64`
+
 Linux: `$ADMIRAL_HOME/tests/install_istio.sh 1.7.4 linux`                                                                                            
 
 * Set up necessary permissions and configurations for Admiral

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DOCKER_REPO?=admiralproj
 IMAGE?=$(DOCKER_REPO)/admiral
 DOCKER_USER?=aattuluri
-KUSTOMIZE_VERSION?=3.8.2
+KUSTOMIZE_VERSION?=4.5.5
 
 DOCKERFILE?=Dockerfile.admiral
 

--- a/install/sample/overlays/rollout-bluegreen/kustomization.yaml
+++ b/install/sample/overlays/rollout-bluegreen/kustomization.yaml
@@ -8,4 +8,3 @@ bases:
 
 resources:
   - greeting.yaml
-  - namespace.yaml

--- a/install/sample/overlays/rollout-bluegreen/namespace.yaml
+++ b/install/sample/overlays/rollout-bluegreen/namespace.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: sample-rollout-bluegreen
-  labels:
-    istio-injection: enabled

--- a/install/sample/overlays/rollout-canary/kustomization.yaml
+++ b/install/sample/overlays/rollout-canary/kustomization.yaml
@@ -8,4 +8,3 @@ bases:
 
 resources:
   - greeting.yaml
-  - namespace.yaml

--- a/install/sample/overlays/rollout-canary/namespace.yaml
+++ b/install/sample/overlays/rollout-canary/namespace.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: sample-rollout-canary
-  labels:
-    istio-injection: enabled

--- a/tests/create_cluster.sh
+++ b/tests/create_cluster.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 
-[ $# -lt 1 ] && { echo "Usage: $0 <k8s_version>" ; exit 1; }
+[ $# -lt 1 ] && { echo "Usage: $0 <k8s_version> "; exit 1; }
 
 k8s_version=$1
+driver="--vm-driver=virtualbox"
+
+# apple silicon does not support virtualbox
+if [[ "$OSTYPE" == "darwin"* && $(uname -m) == 'arm64' ]]; then
+  driver="--driver=docker"
+fi
 
 echo "Creating K8s cluster with version: $k8s_version"
 
@@ -13,7 +19,7 @@ if [[ $IS_LOCAL == "false" ]]; then
   sudo -E minikube start --vm-driver=none --kubernetes-version=$k8s_version
 else
   echo "Creating K8s cluster with virtualbox vm driver"
-  minikube start --memory=4096 --cpus=4 --kubernetes-version=$k8s_version --vm-driver "virtualbox"
+  minikube start --memory=4096 --cpus=4 --kubernetes-version=$k8s_version $driver
   #label node for locality load balancing
   kubectl label nodes minikube --overwrite failure-domain.beta.kubernetes.io/region=us-west-2
 fi

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -12,7 +12,9 @@ source ./create_cluster.sh $k8s_version
 # Uncomment below line if setup fails due to KUBECONFIG not set
 export KUBECONFIG=~/.kube/config
 # change $os from "linux" to "osx" when running on local computer
-if [[ "$OSTYPE" == "darwin"* ]]; then
+if [[ "$OSTYPE" == "darwin"* && $(uname -m) == 'arm64' ]]; then
+  os="osx-arm64"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
   os="osx"
 else
   os="linux-amd64"


### PR DESCRIPTION
Updating instructions for apple silicon, updating kustomize as 3.8.2 version is not supported in apple silicon.