### PR TITLE
provided an ability to create additional endpoints

### DIFF
--- a/admiral/cmd/admiral/cmd/root.go
+++ b/admiral/cmd/admiral/cmd/root.go
@@ -144,6 +144,8 @@ func GetRootCmd(args []string) *cobra.Command {
 		"If Routing Policy feature needs to be enabled")
 	rootCmd.PersistentFlags().StringArrayVar(&params.ExcludedIdentityList, "excluded_identity_list", []string{},
 		"List of identities which should be excluded from getting processed")
+	rootCmd.PersistentFlags().StringArrayVar(&params.AdditionalEndpointSuffixes, "additional_endpoint_suffixes", []string{},
+		"Suffixes that Admiral should use to generate additional endpoints through VirtualServices")
 	return rootCmd
 }
 

--- a/admiral/pkg/clusters/handler.go
+++ b/admiral/pkg/clusters/handler.go
@@ -653,6 +653,20 @@ func getServiceEntryDiff(new *v1alpha3.ServiceEntry, old *v1alpha3.ServiceEntry)
 	return destructive, diff
 }
 
+func deleteVirtualService(ctx context.Context, exist *v1alpha3.VirtualService, namespace string, rc *RemoteController) error {
+	if exist == nil {
+		return fmt.Errorf("the VirtualService passed was nil")
+	}
+	err := rc.VirtualServiceController.IstioClient.NetworkingV1alpha3().VirtualServices(namespace).Delete(ctx, exist.Name, metav1.DeleteOptions{})
+	if err != nil {
+		if k8sErrors.IsNotFound(err) {
+			return fmt.Errorf("either VirtualService was already deleted, or it never existed")
+		}
+		return err
+	}
+	return nil
+}
+
 func deleteServiceEntry(ctx context.Context, exist *v1alpha3.ServiceEntry, namespace string, rc *RemoteController) {
 	if exist != nil {
 		err := rc.ServiceEntryController.IstioClient.NetworkingV1alpha3().ServiceEntries(namespace).Delete(ctx, exist.Name, metav1.DeleteOptions{})

--- a/admiral/pkg/clusters/serviceentry.go
+++ b/admiral/pkg/clusters/serviceentry.go
@@ -716,6 +716,7 @@ func createAdditionalEndpoints(ctx context.Context, serviceEntry *networking.Ser
 	}
 
 	defaultVSName := getIstioResourceName(virtualServiceHostnames[0], "-vs")
+	//nolint
 	virtualService := createVirtualServiceSkeleton(vs, defaultVSName, namespace)
 	err := createOrUpdateVirtualService(ctx, rc, virtualService)
 	if err != nil {

--- a/admiral/pkg/clusters/serviceentry.go
+++ b/admiral/pkg/clusters/serviceentry.go
@@ -328,9 +328,6 @@ func getAdmiralGeneratedVirtualService(ctx context.Context, remoteController *Re
 			result = existingVS
 		}
 	}
-	if result == nil {
-		return nil, fmt.Errorf("no virtualservice found with labels %s and annotation %s=%s", listOptions.LabelSelector, resourceCreatedByAnnotationLabel, resourceCreatedByAnnotationValue)
-	}
 	return result, nil
 }
 
@@ -679,6 +676,11 @@ func deleteAdditionalEndpoints(ctx context.Context, rc *RemoteController, identi
 	vsToDelete, err := getAdmiralGeneratedVirtualService(ctx, rc, listOptions, namespace)
 	if err != nil {
 		return err
+	}
+
+	if vsToDelete == nil {
+		log.Debug("skipped additional endpoints cleanup as no virtualservice was found to delete")
+		return nil
 	}
 
 	err = deleteVirtualService(ctx, vsToDelete, namespace, rc)

--- a/admiral/pkg/clusters/serviceentry_test.go
+++ b/admiral/pkg/clusters/serviceentry_test.go
@@ -2532,28 +2532,17 @@ func TestCreateAdditionalEndpoints(t *testing.T) {
 		expectedVS                 []*v1alpha3.VirtualService
 	}{
 		{
-			name:                       "Given SE and additional endpoint suffixes, when additional endpoint suffixes is empty, func should not return an error and should not generate any additional endpoints",
-			additionalEndpointSuffixes: []string{},
-			rc: &RemoteController{
-				VirtualServiceController: &istio.VirtualServiceController{
-					IstioClient: istiofake.NewSimpleClientset(),
-				},
-			},
-			expectedError: nil,
-			expectedVS:    []*v1alpha3.VirtualService{},
-		},
-		{
 			name:                       "Given additional endpoint suffixes, when passed identity is empty, func should return an error",
 			identity:                   "",
 			additionalEndpointSuffixes: []string{"foo"},
-			expectedError:              fmt.Errorf("failed generating additional endpoints as identity passed is empty"),
+			expectedError:              fmt.Errorf("identity passed is empty"),
 		},
 		{
 			name:                       "Given additional endpoint suffixes, when passed env is empty, func should return an error",
 			identity:                   "test00",
 			env:                        "",
 			additionalEndpointSuffixes: []string{"foo"},
-			expectedError:              fmt.Errorf("failed generating additional endpoints as env passed is empty"),
+			expectedError:              fmt.Errorf("env passed is empty"),
 		},
 		{
 			name:                       "Given additional endpoint suffixes, when valid identity,env and additional suffix params are passed, func should not return any error and create desired virtualservices",
@@ -2647,27 +2636,17 @@ func TestDeleteAdditionalEndpoints(t *testing.T) {
 		expectedDeletedVSName      string
 	}{
 		{
-			name:                       "Given additional endpoint suffixes, when additional endpoint suffixes is empty, func should not return an error",
-			additionalEndpointSuffixes: []string{},
-			rc: &RemoteController{
-				VirtualServiceController: &istio.VirtualServiceController{
-					IstioClient: istiofake.NewSimpleClientset(),
-				},
-			},
-			expectedError: nil,
-		},
-		{
 			name:                       "Given additional endpoint suffixes, when passed identity is empty, func should return an error",
 			identity:                   "",
 			additionalEndpointSuffixes: []string{"foo"},
-			expectedError:              fmt.Errorf("failed deleting additional endpoints as identity passed is empty"),
+			expectedError:              fmt.Errorf("identity passed is empty"),
 		},
 		{
 			name:                       "Given additional endpoint suffixes, when passed env is empty, func should return an error",
 			identity:                   "test00",
 			env:                        "",
 			additionalEndpointSuffixes: []string{"foo"},
-			expectedError:              fmt.Errorf("failed deleting additional endpoints as env passed is empty"),
+			expectedError:              fmt.Errorf("env passed is empty"),
 		},
 		{
 			name:                       "Given additional endpoint suffixes, when valid identity,env and additional suffix params are passed and VS intended to be deleted does not exists, func should return an error",
@@ -2754,12 +2733,6 @@ func TestGetAdmiralGeneratedVirtualService(t *testing.T) {
 			expectedError:  fmt.Errorf("no virtualservice found with labels"),
 		},
 		{
-			name:           "Given valid listOptions, when VS matches the listOption labels and it is not created by admiral, func should return an error",
-			labels:         map[string]string{"admiral.io/env": "stage", "identity": "test00"},
-			virtualService: fooVS,
-			expectedError:  fmt.Errorf("no virtualservice found with labels admiral.io/env=stage,identity=test00 and annotation app.kubernetes.io/created-by=admiral"),
-		},
-		{
 			name:           "Given valid listOptions, when VS matches the listOption labels and it is created by admiral, func should not return an error and return the VS",
 			labels:         map[string]string{"admiral.io/env": "stage", "identity": "test00"},
 			annotations:    map[string]string{resourceCreatedByAnnotationLabel: resourceCreatedByAnnotationValue},
@@ -2785,7 +2758,7 @@ func TestGetAdmiralGeneratedVirtualService(t *testing.T) {
 					IstioClient: validIstioClient,
 				},
 			}
-			labelSelector, _ := labels.ValidatedSelectorFromSet(tc.labels)
+			labelSelector, _ := labels.ValidatedSelectorFromSet(map[string]string{"admiral.io/env": "stage", "identity": "test00"})
 			listOptions := metav1.ListOptions{
 				LabelSelector: labelSelector.String(),
 			}

--- a/admiral/pkg/controller/common/config.go
+++ b/admiral/pkg/controller/common/config.go
@@ -75,6 +75,10 @@ func GetLabelSet() *LabelSet {
 	return admiralParams.LabelSet
 }
 
+func GetAdditionalEndpointSuffixes() []string {
+	return admiralParams.AdditionalEndpointSuffixes
+}
+
 func GetHostnameSuffix() string {
 	return admiralParams.HostnameSuffix
 }

--- a/admiral/pkg/controller/common/types.go
+++ b/admiral/pkg/controller/common/types.go
@@ -52,6 +52,7 @@ type AdmiralParams struct {
 	EnvoyFilterAdditionalConfig string
 	EnableRoutingPolicy         bool
 	ExcludedIdentityList        []string
+	AdditionalEndpointSuffixes  []string
 }
 
 func (b AdmiralParams) String() string {


### PR DESCRIPTION
## Provides an ability to generate additional endpoints for a service

The additional endpoints will be generated based on the `additional_endpoints_suffixes` array passed as the command line param. 
Admiral will use the passed suffixes to generate the endpoints by creating a VirtualService, which will route the corresponding ServiceEntry endpoint