### PR TITLE
[MESH-3036] - Set consecutive5xxErrors to 0

### DIFF
--- a/admiral/pkg/clusters/handler.go
+++ b/admiral/pkg/clusters/handler.go
@@ -30,6 +30,7 @@ import (
 const (
 	DefaultBaseEjectionTime         int64  = 300
 	DefaultConsecutiveGatewayErrors uint32 = 50
+	DefaultConsecutive5xxErrors     uint32 = 0
 	DefaultInterval                 int64  = 60
 	DefaultHTTP2MaxRequests         int32  = 1000
 	DefaultMaxRequestsPerConnection int32  = 100
@@ -142,7 +143,9 @@ func getOutlierDetection(se *networkingv1alpha3.ServiceEntry, locality string, g
 	outlierDetection := &networkingv1alpha3.OutlierDetection{
 		BaseEjectionTime:         &duration.Duration{Seconds: DefaultBaseEjectionTime},
 		ConsecutiveGatewayErrors: &wrappers.UInt32Value{Value: DefaultConsecutiveGatewayErrors},
-		Interval:                 &duration.Duration{Seconds: DefaultInterval},
+		// The default Consecutive5XXErrors is set to 5 in envoy, setting to 0 disables 5XX error outlier detection so that ConsecutiveGatewayErrors rule can get evaluated
+		Consecutive_5XxErrors: &wrappers.UInt32Value{Value: DefaultConsecutive5xxErrors},
+		Interval:              &duration.Duration{Seconds: DefaultInterval},
 	}
 
 	if gtpTrafficPolicy != nil && gtpTrafficPolicy.OutlierDetection != nil {

--- a/admiral/pkg/clusters/handler_test.go
+++ b/admiral/pkg/clusters/handler_test.go
@@ -330,6 +330,7 @@ func TestGetOutlierDetection(t *testing.T) {
 	outlierDetection := &v1alpha3.OutlierDetection{
 		BaseEjectionTime:         &duration.Duration{Seconds: DefaultBaseEjectionTime},
 		ConsecutiveGatewayErrors: &wrappers.UInt32Value{Value: DefaultConsecutiveGatewayErrors},
+		Consecutive_5XxErrors:    &wrappers.UInt32Value{Value: DefaultConsecutive5xxErrors},
 		Interval:                 &duration.Duration{Seconds: DefaultInterval},
 		MaxEjectionPercent:       100,
 	}
@@ -337,6 +338,7 @@ func TestGetOutlierDetection(t *testing.T) {
 	outlierDetectionOneHostRemote := &v1alpha3.OutlierDetection{
 		BaseEjectionTime:         &duration.Duration{Seconds: DefaultBaseEjectionTime},
 		ConsecutiveGatewayErrors: &wrappers.UInt32Value{Value: DefaultConsecutiveGatewayErrors},
+		Consecutive_5XxErrors:    &wrappers.UInt32Value{Value: DefaultConsecutive5xxErrors},
 		Interval:                 &duration.Duration{Seconds: DefaultInterval},
 		MaxEjectionPercent:       34,
 	}
@@ -438,6 +440,7 @@ func TestGetOutlierDetection(t *testing.T) {
 			outlierDetection: &v1alpha3.OutlierDetection{
 				BaseEjectionTime:         &duration.Duration{Seconds: DefaultBaseEjectionTime},
 				ConsecutiveGatewayErrors: &wrappers.UInt32Value{Value: 10},
+				Consecutive_5XxErrors:    &wrappers.UInt32Value{Value: 0},
 				Interval:                 &duration.Duration{Seconds: 60},
 				MaxEjectionPercent:       100,
 			},
@@ -462,6 +465,7 @@ func TestGetOutlierDetection(t *testing.T) {
 			outlierDetection: &v1alpha3.OutlierDetection{
 				BaseEjectionTime:         &duration.Duration{Seconds: 600},
 				ConsecutiveGatewayErrors: &wrappers.UInt32Value{Value: DefaultConsecutiveGatewayErrors},
+				Consecutive_5XxErrors:    &wrappers.UInt32Value{Value: DefaultConsecutive5xxErrors},
 				Interval:                 &duration.Duration{Seconds: 60},
 				MaxEjectionPercent:       100,
 			},
@@ -486,6 +490,7 @@ func TestGetOutlierDetection(t *testing.T) {
 			outlierDetection: &v1alpha3.OutlierDetection{
 				BaseEjectionTime:         &duration.Duration{Seconds: 600},
 				ConsecutiveGatewayErrors: &wrappers.UInt32Value{Value: 50},
+				Consecutive_5XxErrors:    &wrappers.UInt32Value{Value: 0},
 				Interval:                 &duration.Duration{Seconds: DefaultInterval},
 				MaxEjectionPercent:       100,
 			},
@@ -511,6 +516,7 @@ func TestGetOutlierDetection(t *testing.T) {
 			outlierDetection: &v1alpha3.OutlierDetection{
 				BaseEjectionTime:         &duration.Duration{Seconds: 600},
 				ConsecutiveGatewayErrors: &wrappers.UInt32Value{Value: 10},
+				Consecutive_5XxErrors:    &wrappers.UInt32Value{Value: 0},
 				Interval:                 &duration.Duration{Seconds: 60},
 				MaxEjectionPercent:       100,
 			},

--- a/admiral/pkg/clusters/handler_test.go
+++ b/admiral/pkg/clusters/handler_test.go
@@ -179,6 +179,7 @@ func TestGetDestinationRule(t *testing.T) {
 	outlierDetection := &v1alpha3.OutlierDetection{
 		BaseEjectionTime:         &duration.Duration{Seconds: 300},
 		ConsecutiveGatewayErrors: &wrappers.UInt32Value{Value: 50},
+		Consecutive_5XxErrors:    &wrappers.UInt32Value{Value: 0},
 		Interval:                 &duration.Duration{Seconds: 60},
 		MaxEjectionPercent:       100,
 	}


### PR DESCRIPTION
ConsecutiveGatewayErrors in DestinationRule do not take affect the value is higher that consecutive5xxErrors.

In [envoy](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/outlier_detection.proto#envoy-v3-api-field-config-cluster-v3-outlierdetection-consecutive-5xx) consecutive5xxErrors value is set to 5 by default. 

consecutive5xxErrors needs to be set to 0, to explicitly disable the 5XX error outlier detection to kick in.