### PR TITLE
[MESH-2984] - Adding vm_id to dynamic routing envoyFilter

### DIFF
--- a/admiral/pkg/clusters/envoyfilter.go
+++ b/admiral/pkg/clusters/envoyfilter.go
@@ -109,10 +109,11 @@ func constructEnvoyFilterStruct(routingPolicy *v1.RoutingPolicy, workloadSelecto
 			"value": {Kind: &structpb.Value_StringValue{StringValue: envoyFilterStringConfig}},
 		},
 	}
-
+	
 	vmConfig := structpb.Struct{
 		Fields: map[string]*structpb.Value{
 			"runtime": {Kind: &structpb.Value_StringValue{StringValue: "envoy.wasm.runtime.v8"}},
+			"vm_id":   {Kind: &structpb.Value_StringValue{StringValue: routingPolicy.Spec.Plugin}},
 			"code": {Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: map[string]*structpb.Value{
 				"local": {Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: map[string]*structpb.Value{
 					"filename": {Kind: &structpb.Value_StringValue{StringValue: wasmPath}},

--- a/admiral/pkg/clusters/envoyfilter_test.go
+++ b/admiral/pkg/clusters/envoyfilter_test.go
@@ -114,6 +114,10 @@ func TestCreateOrUpdateEnvoyFilter(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Nil(t, envoyfilter3)
 
+	//TODO: Convert to table tests
+	envoyfiltervmid, err := createOrUpdateEnvoyFilter(ctx, remoteController, routingPolicyFoo, admiral.Add, "bar", registry.AdmiralCache, selectors)
+	vm_id := envoyfiltervmid.Spec.ConfigPatches[0].Patch.Value.Fields["typed_config"].GetStructValue().Fields["value"].GetStructValue().Fields["config"].GetStructValue().Fields["vm_config"].GetStructValue().Fields["vm_id"].GetStringValue()
+	assert.Equal(t, "test", vm_id)
 }
 
 func getSha1Error(key interface{}) (string, error) {


### PR DESCRIPTION
What does this change do and why?
vm_id in envoy filter allows the wasm vm to be unique, this will allow multiple filters with different environments to work on the same envoy instance. Example e2e, e2e2 , e2e3. This case before this change would use the same vm in wasm causing issues with config merging.

More info on VM sharing - https://github.com/tetratelabs/proxy-wasm-go-sdk/blob/main/doc/OVERVIEW.md