### PR TITLE
add interface for getting configurations

### DIFF
--- a/admiral/pkg/registry/registry.go
+++ b/admiral/pkg/registry/registry.go
@@ -1,0 +1,10 @@
+package registry
+
+// IdentityConfiguration is an interface to fetch configuration from a registry
+// backend. The backend can provide an API to give configurations per identity,
+// or if given a cluster name, it will provide the configurations for all
+// the identities present in that cluster.
+type IdentityConfiguration interface {
+	GetByIdentity(identityAlias string) error
+	GetByCluster(clusterName string) error
+}

--- a/admiral/pkg/registry/registry.go
+++ b/admiral/pkg/registry/registry.go
@@ -5,6 +5,6 @@ package registry
 // or if given a cluster name, it will provide the configurations for all
 // the identities present in that cluster.
 type IdentityConfiguration interface {
-	GetByIdentity(identityAlias string) error
-	GetByCluster(clusterName string) error
+	GetByIdentityByName(identityAlias string) error
+	GetByClusterName(clusterName string) error
 }


### PR DESCRIPTION
## Description
What does this change do and why?
Adds an interface for fetching configurations for a given identity, or all the identities in a given cluister.