### PR TITLE
Update Shard status processing

### DIFF
--- a/admiral/pkg/clusters/shard_handler.go
+++ b/admiral/pkg/clusters/shard_handler.go
@@ -326,10 +326,11 @@ func retryUpdatingShard(ctx context.Context, ctxLogger *log.Entry, obj *admirala
 			}
 			ctxLogger.Infof(common.CtxLogFormat, "Update", obj.Name, obj.Namespace, "", fmt.Sprintf("existingResourceVersion=%s resourceVersionUsedForUpdate=%s", updatedShard.ResourceVersion, obj.ResourceVersion))
 			updatedShard.Spec = obj.Spec
+			updatedShard.Status = obj.Status
 			updatedShard.Annotations = obj.Annotations
 			updatedShard.Labels = obj.Labels
-			_, err = cc.AdmiralV1().Shards(exist.Namespace).Update(ctx, exist, v1.UpdateOptions{})
-			if err == nil {
+			sh, err := cc.AdmiralV1().Shards(exist.Namespace).Update(ctx, updatedShard, v1.UpdateOptions{})
+			if err == nil || sh == nil {
 				return nil
 			}
 		}

--- a/admiral/pkg/controller/admiral/shard.go
+++ b/admiral/pkg/controller/admiral/shard.go
@@ -21,7 +21,7 @@ import (
 const OperatorIdentityLabelKey = "admiral.io/operatorIdentity"
 
 type ShardHandler interface {
-	Added(ctx context.Context, obj *admiralapiv1.Shard) error
+	Added(ctx context.Context, obj *admiralapiv1.Shard, cc admiralapi.Interface) error
 	Deleted(ctx context.Context, obj *admiralapiv1.Shard) error
 }
 
@@ -200,7 +200,7 @@ func HandleAddUpdateShard(ctx context.Context, obj interface{}, d *ShardControll
 	if len(key) > 0 {
 		d.Cache.UpdateShardToClusterCache(key, shard)
 	}
-	err := d.ShardHandler.Added(ctx, shard)
+	err := d.ShardHandler.Added(ctx, shard, d.CrdClient)
 	return err
 }
 

--- a/admiral/pkg/test/mock.go
+++ b/admiral/pkg/test/mock.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	admiralapiv1 "github.com/istio-ecosystem/admiral-api/pkg/apis/admiral/v1"
+	admiralapi "github.com/istio-ecosystem/admiral-api/pkg/client/clientset/versioned"
 
 	argoprojv1alpha1 "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/typed/rollouts/v1alpha1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -417,7 +418,7 @@ func (m *MockOutlierDetectionHandler) Deleted(ctx context.Context, obj *admiralV
 type MockShardHandler struct {
 }
 
-func (m *MockShardHandler) Added(ctx context.Context, obj *admiralapiv1.Shard) error {
+func (m *MockShardHandler) Added(ctx context.Context, obj *admiralapiv1.Shard, cc admiralapi.Interface) error {
 	return nil
 }
 


### PR DESCRIPTION
Shard handler now updates the shard status while producing networking resources from it.
Added tests for some of the shard status processing methods.