### PR TITLE
Mesh 3865 - Adding unique VS name for copy VS feature

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
 
   run-integration-tests:
     machine:
-      image: ubuntu-2004:202010-01
+      image: ubuntu-2004:2024.04.4
     environment:
       K8S_VERSION: v1.25.2
       KUBECONFIG: /home/circleci/.kube/config

--- a/admiral/pkg/controller/common/common.go
+++ b/admiral/pkg/controller/common/common.go
@@ -703,22 +703,22 @@ func GetMeshPortsHelper(meshPorts string, destService *k8sV1.Service, clusterNam
 	return ports
 }
 
-func GenerateUniqueNameForVS(syncNamespace string, vsName string) string {
+func GenerateUniqueNameForVS(originNamespace string, vsName string) string {
 
-	if syncNamespace == "" && vsName == "" {
+	if originNamespace == "" && vsName == "" {
 		return ""
-	} else if syncNamespace == "" {
+	} else if originNamespace == "" {
 		return vsName
 	} else if vsName == "" {
-		return syncNamespace
+		return originNamespace
 	}
 
-	newVSName := syncNamespace + "-" + vsName
+	newVSName := originNamespace + "-" + vsName
 	if len(newVSName) > 250 {
 		newVSName = newVSName[:250]
 	}
 	//"op=%v type=%v name=%v namespace=%s cluster=%s message=%v"
-	logrus.Debugf(LogFormatAdv, "VirtualService", newVSName, syncNamespace, "", "New VS name generated")
+	logrus.Debugf(LogFormatAdv, "VirtualService", newVSName, originNamespace, "", "New VS name generated")
 
 	return newVSName
 

--- a/admiral/pkg/controller/common/common.go
+++ b/admiral/pkg/controller/common/common.go
@@ -702,3 +702,24 @@ func GetMeshPortsHelper(meshPorts string, destService *k8sV1.Service, clusterNam
 	}
 	return ports
 }
+
+func GenerateUniqueNameForVS(syncNamespace string, vsName string) string {
+
+	if syncNamespace == "" && vsName == "" {
+		return ""
+	} else if syncNamespace == "" {
+		return vsName
+	} else if vsName == "" {
+		return syncNamespace
+	}
+
+	newVSName := syncNamespace + "-" + vsName
+	if len(newVSName) > 250 {
+		newVSName = newVSName[:250]
+	}
+	//"op=%v type=%v name=%v namespace=%s cluster=%s message=%v"
+	logrus.Debugf(LogFormatAdv, "VirtualService", newVSName, syncNamespace, "", "New VS name generated")
+
+	return newVSName
+
+}

--- a/admiral/pkg/controller/common/common.go
+++ b/admiral/pkg/controller/common/common.go
@@ -707,9 +707,13 @@ func GenerateUniqueNameForVS(originNamespace string, vsName string) string {
 
 	if originNamespace == "" && vsName == "" {
 		return ""
-	} else if originNamespace == "" {
+	}
+
+	if originNamespace == "" {
 		return vsName
-	} else if vsName == "" {
+	}
+
+	if vsName == "" {
 		return originNamespace
 	}
 

--- a/admiral/pkg/controller/common/common_test.go
+++ b/admiral/pkg/controller/common/common_test.go
@@ -1181,3 +1181,59 @@ func TestGetGtpIdentityPartition(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateUniqueNameForVS(t *testing.T) {
+	initConfig(true, true)
+
+	testCases := []struct {
+		name     string
+		vsName   string
+		nsName   string
+		expected string
+	}{
+		{
+			name: "Given valid namespace name and virtual service name" +
+				"Should return valid vsname ",
+			vsName:   "test-vs",
+			nsName:   "test-ns",
+			expected: "test-ns-test-vs",
+		},
+		{
+			name: "Given valid namespace name and nil virtual service name" +
+				"Should return valid vsname with only namespace name ",
+			vsName:   "",
+			nsName:   "test-ns",
+			expected: "test-ns",
+		},
+		{
+			name: "Given nil namespace name and valid virtual service name" +
+				"Should return valid vsname with only vs name ",
+			vsName:   "test-vs",
+			nsName:   "",
+			expected: "test-vs",
+		},
+		{
+			name: "Given valid namespace name and virtual service name over 250 chars long" +
+				"Should return valid truncated vsname",
+			vsName:   "mbjwbsaabyxpitryeptqtgcwfkseodgqgvoccktivzfqlzdbxhctplqhqixuxpeqjcsrgzaxxbfphasmrkpkyeosxxljmsqalmfublwcecztwgdtkulcrfwiwqqza123",
+			nsName:   "mbjwbsaabyxpitryeptqtgcwfkseodgqgvoccktivzfqlzdbxhctplqhqixuxpeqjcsrgzaxxbfphasmrkpkyeosxxljmsqalmfublwcecztwgdtkulcrfwiwqqza123",
+			expected: "mbjwbsaabyxpitryeptqtgcwfkseodgqgvoccktivzfqlzdbxhctplqhqixuxpeqjcsrgzaxxbfphasmrkpkyeosxxljmsqalmfublwcecztwgdtkulcrfwiwqqza123-mbjwbsaabyxpitryeptqtgcwfkseodgqgvoccktivzfqlzdbxhctplqhqixuxpeqjcsrgzaxxbfphasmrkpkyeosxxljmsqalmfublwcecztwgdtkulcrfwiw",
+		},
+		{
+			name: "Given nil namespace name and nil virtual service name" +
+				"Should return nil vsname ",
+			vsName:   "",
+			nsName:   "",
+			expected: "",
+		},
+	}
+
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+			iVal := GenerateUniqueNameForVS(c.nsName, c.vsName)
+			if !(iVal == c.expected) {
+				t.Errorf("Wanted value: %s, got: %s", c.expected, iVal)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Checklist
🚨 Please review this repository's [contribution guidelines](./CONTRIBUTING.md).

- [ ] I've read and agree to the project's contribution guidelines.
- [ ] I'm requesting to **pull a topic/feature/bugfix branch**.
- [ ] I checked that my code additions will pass code linting checks and unit tests.
- [ ] I updated unit and integration tests (if applicable).
- [ ] I'm ready to notify the team of this contribution.

### Description
What does this change do and why?

This change makes sure that the virtual service that gets copied across different clusters does not get over-written. It assumes that the namespace-vsname combination is unique.

Thank you!