### PR TITLE
Modify IdentityConfig to support different deploy/rollout strategies

### DIFF
--- a/admiral/pkg/clusters/shard_handler.go
+++ b/admiral/pkg/clusters/shard_handler.go
@@ -134,11 +134,12 @@ func ProduceIdentityConfigsFromShard(ctxLogger *log.Entry, shard admiralapiv1.Sh
 					}
 					// Fill the DependencyNamespaceCache
 					for _, clientAsset := range identityConfig.ClientAssets {
-						//TODO: How to deal with multiple services here?
 						cname := common.GetCnameVal([]string{identityConfigEnv.Name, strings.ToLower(identityConfig.IdentityName), common.GetHostnameSuffix()})
 						cnames[cname] = "1"
-						localFqdn := identityConfigEnv.ServiceName + common.Sep + identityConfigEnv.Namespace + common.GetLocalDomainSuffix()
-						rr.AdmiralCache.DependencyNamespaceCache.Put(clientAsset, identityConfigEnv.Namespace, localFqdn, cnames)
+						for _, service := range identityConfigEnv.Services {
+							localFqdn := service.Name + common.Sep + identityConfigEnv.Namespace + common.GetLocalDomainSuffix()
+							rr.AdmiralCache.DependencyNamespaceCache.Put(clientAsset, identityConfigEnv.Namespace, localFqdn, cnames)
+						}
 					}
 				}
 				// Fill the ClusterLocalityCache

--- a/admiral/pkg/clusters/testdata/sampleIdentityConfiguration.json
+++ b/admiral/pkg/clusters/testdata/sampleIdentityConfiguration.json
@@ -10,294 +10,413 @@
       "ingressPortName": "http",
       "_comment-2": "THIS SECTION CONTAINS ENVIRONMENT LEVEL DETAILS, FOR THE ASSET IN A GIVEN CLUSTER",
       "environment": {
-        "prf": {
-          "name": "prf",
-          "namespace": "ns-1-usw2-prf",
-          "serviceName": "app-1-spk-root-service",
-          "services": {
-            "app-1-spk-root-service": {
-              "name": "app-1-spk-root-service",
-              "weight": -1,
-              "ports": {
-                "http": 8090
-              }
-            }
-          },
-          "type": "rollout",
-          "selectors": {
-            "app": "app-1"
-          },
-          "ports": [
-            {
-              "name": "http",
-              "number": 80,
-              "protocol": "http"
-            }
-          ],
-          "trafficPolicy": {
-            "clientConnectionConfig": {
-              "metadata": {
-                "name": "sampleCCC",
-                "labels": {
-                  "identity": "sample"
-                },
-                "annotations": {
-                  "env": "prf"
+        "prf": [
+          {
+            "name": "prf",
+            "namespace": "ns-1-usw2-prf",
+            "strategy": "canary",
+            "services": {
+              "root": {
+                "name": "app-1-spk-root-service",
+                "weight": -1,
+                "ports": {
+                  "http": 8090
                 }
               },
-              "spec": {
-                "connectionPool": {
-                  "http": {
-                    "http2MaxRequests": 1000,
-                    "maxRequestsPerConnection": 5
-                  }
-                },
-                "tunnel": {}
+              "stable": {
+                "name": "app-1-spk-stable-service",
+                "weight": 25,
+                "ports": {
+                  "http": 8090
+                }
+              },
+              "desired": {
+                "name": "app-1-spk-desired-service",
+                "weight": 75,
+                "ports": {
+                  "http": 8090
+                }
               }
             },
-            "globalTrafficPolicy": {
-              "metadata": {
-                "name": "sampleGTP",
-                "labels": {
-                  "identity": "sample"
+            "type": "rollout",
+            "selectors": {
+              "app": "app-1"
+            },
+            "ports": [
+              {
+                "name": "http",
+                "number": 80,
+                "protocol": "http"
+              }
+            ],
+            "trafficPolicy": {
+              "clientConnectionConfig": {
+                "metadata": {
+                  "name": "sampleCCC",
+                  "labels": {
+                    "identity": "sample"
+                  },
+                  "annotations": {
+                    "env": "prf"
+                  }
                 },
-                "annotations": {
-                  "env": "prf"
-                }
-              },
-              "spec": {
-                "policy": [
-                  {
-                    "target": [
-                      {
-                        "region": "us-west-2",
-                        "weight": 50
-                      },
-                      {
-                        "region": "us-east-2",
-                        "weight": 50
-                      }
-                    ],
-                    "dnsPrefix": "testDnsPrefix",
-                    "outlier_detection": {
-                      "consecutive_gateway_errors": 5,
-                      "interval": 5
+                "spec": {
+                  "connectionPool": {
+                    "http": {
+                      "http2MaxRequests": 1000,
+                      "maxRequestsPerConnection": 5
                     }
-                  }
-                ]
-              }
-            },
-            "outlierDetection": {
-              "metadata": {
-                "name": "sampleOD",
-                "labels": {
-                  "identity": "sample"
-                },
-                "annotations": {
-                  "env": "prf"
+                  },
+                  "tunnel": {}
                 }
               },
-              "spec": {
-                "outlier_config": {
-                  "consecutive_gateway_errors": 10,
-                  "interval": 10
+              "globalTrafficPolicy": {
+                "metadata": {
+                  "name": "sampleGTP",
+                  "labels": {
+                    "identity": "sample"
+                  },
+                  "annotations": {
+                    "env": "prf"
+                  }
+                },
+                "spec": {
+                  "policy": [
+                    {
+                      "target": [
+                        {
+                          "region": "us-west-2",
+                          "weight": 50
+                        },
+                        {
+                          "region": "us-east-2",
+                          "weight": 50
+                        }
+                      ],
+                      "dnsPrefix": "testDnsPrefix",
+                      "outlier_detection": {
+                        "consecutive_gateway_errors": 5,
+                        "interval": 5
+                      }
+                    }
+                  ]
+                }
+              },
+              "outlierDetection": {
+                "metadata": {
+                  "name": "sampleOD",
+                  "labels": {
+                    "identity": "sample"
+                  },
+                  "annotations": {
+                    "env": "prf"
+                  }
+                },
+                "spec": {
+                  "outlier_config": {
+                    "consecutive_gateway_errors": 10,
+                    "interval": 10
+                  }
+                }
+              }
+            }
+          },
+          {
+            "name": "prf",
+            "namespace": "ns-1-usw2-prf",
+            "app-1-spk-service": {
+              "root": {
+                "name": "app-1-spk-service",
+                "weight": -1,
+                "ports": {
+                  "http": 8090
+                }
+              }
+            },
+            "type": "deployment",
+            "selectors": {
+              "app": "app-1"
+            },
+            "ports": [
+              {
+                "name": "http",
+                "number": 80,
+                "protocol": "http"
+              }
+            ],
+            "trafficPolicy": {
+              "clientConnectionConfig": {
+                "metadata": {
+                  "name": "sampleCCC",
+                  "labels": {
+                    "identity": "sample"
+                  },
+                  "annotations": {
+                    "env": "prf"
+                  }
+                },
+                "spec": {
+                  "connectionPool": {
+                    "http": {
+                      "http2MaxRequests": 1000,
+                      "maxRequestsPerConnection": 5
+                    }
+                  },
+                  "tunnel": {}
+                }
+              },
+              "globalTrafficPolicy": {
+                "metadata": {
+                  "name": "sampleGTP",
+                  "labels": {
+                    "identity": "sample"
+                  },
+                  "annotations": {
+                    "env": "prf"
+                  }
+                },
+                "spec": {
+                  "policy": [
+                    {
+                      "target": [
+                        {
+                          "region": "us-west-2",
+                          "weight": 50
+                        },
+                        {
+                          "region": "us-east-2",
+                          "weight": 50
+                        }
+                      ],
+                      "dnsPrefix": "testDnsPrefix",
+                      "outlier_detection": {
+                        "consecutive_gateway_errors": 5,
+                        "interval": 5
+                      }
+                    }
+                  ]
+                }
+              },
+              "outlierDetection": {
+                "metadata": {
+                  "name": "sampleOD",
+                  "labels": {
+                    "identity": "sample"
+                  },
+                  "annotations": {
+                    "env": "prf"
+                  }
+                },
+                "spec": {
+                  "outlier_config": {
+                    "consecutive_gateway_errors": 10,
+                    "interval": 10
+                  }
                 }
               }
             }
           }
-        },
-        "e2e": {
-          "name": "e2e",
-          "namespace": "ns-1-usw2-e2e",
-          "serviceName": "app-1-spk-root-service",
-          "services": {
-            "app-1-spk-root-service": {
-              "name": "app-1-spk-root-service",
-              "weight": -1,
-              "ports": {
-                "http": 8090
-              }
-            }
-          },
-          "type": "rollout",
-          "selectors": {
-            "app": "app-1"
-          },
-          "ports": [
-            {
-              "name": "http",
-              "number": 80,
-              "protocol": "http"
-            }
-          ],
-          "trafficPolicy": {
-            "clientConnectionConfig": {
-              "metadata": {
-                "name": "sampleCCC",
-                "labels": {
-                  "identity": "sample"
-                },
-                "annotations": {
-                  "env": "e2e"
+        ],
+        "e2e": [
+          {
+            "name": "e2e",
+            "namespace": "ns-1-usw2-e2e",
+            "strategy": "bluegreen",
+            "services": {
+              "preview": {
+                "name": "app-1-spk-preview-service",
+                "ports": {
+                  "http": 8090
                 }
               },
-              "spec": {
-                "connectionPool": {
-                  "http": {
-                    "http2MaxRequests": 1000,
-                    "maxRequestsPerConnection": 5
-                  }
-                },
-                "tunnel": {}
+              "desired": {
+                "name": "app-1-spk-desired-service",
+                "ports": {
+                  "http": 8090
+                }
               }
             },
-            "globalTrafficPolicy": {
-              "metadata": {
-                "name": "sampleGTP",
-                "labels": {
-                  "identity": "sample"
+            "type": "rollout",
+            "selectors": {
+              "app": "app-1"
+            },
+            "ports": [
+              {
+                "name": "http",
+                "number": 80,
+                "protocol": "http"
+              }
+            ],
+            "trafficPolicy": {
+              "clientConnectionConfig": {
+                "metadata": {
+                  "name": "sampleCCC",
+                  "labels": {
+                    "identity": "sample"
+                  },
+                  "annotations": {
+                    "env": "e2e"
+                  }
                 },
-                "annotations": {
-                  "env": "e2e"
-                }
-              },
-              "spec": {
-                "policy": [
-                  {
-                    "target": [
-                      {
-                        "region": "us-west-2",
-                        "weight": 50
-                      },
-                      {
-                        "region": "us-east-2",
-                        "weight": 50
-                      }
-                    ],
-                    "dnsPrefix": "testDnsPrefix",
-                    "outlier_detection": {
-                      "consecutive_gateway_errors": 5,
-                      "interval": 5
+                "spec": {
+                  "connectionPool": {
+                    "http": {
+                      "http2MaxRequests": 1000,
+                      "maxRequestsPerConnection": 5
                     }
-                  }
-                ]
-              }
-            },
-            "outlierDetection": {
-              "metadata": {
-                "name": "sampleOD",
-                "labels": {
-                  "identity": "sample"
-                },
-                "annotations": {
-                  "env": "e2e"
+                  },
+                  "tunnel": {}
                 }
               },
-              "spec": {
-                "outlier_config": {
-                  "consecutive_gateway_errors": 10,
-                  "interval": 10
+              "globalTrafficPolicy": {
+                "metadata": {
+                  "name": "sampleGTP",
+                  "labels": {
+                    "identity": "sample"
+                  },
+                  "annotations": {
+                    "env": "e2e"
+                  }
+                },
+                "spec": {
+                  "policy": [
+                    {
+                      "target": [
+                        {
+                          "region": "us-west-2",
+                          "weight": 50
+                        },
+                        {
+                          "region": "us-east-2",
+                          "weight": 50
+                        }
+                      ],
+                      "dnsPrefix": "testDnsPrefix",
+                      "outlier_detection": {
+                        "consecutive_gateway_errors": 5,
+                        "interval": 5
+                      }
+                    }
+                  ]
+                }
+              },
+              "outlierDetection": {
+                "metadata": {
+                  "name": "sampleOD",
+                  "labels": {
+                    "identity": "sample"
+                  },
+                  "annotations": {
+                    "env": "e2e"
+                  }
+                },
+                "spec": {
+                  "outlier_config": {
+                    "consecutive_gateway_errors": 10,
+                    "interval": 10
+                  }
                 }
               }
             }
           }
-        },
-        "qal": {
-          "name": "qal",
-          "namespace": "ns-1-usw2-qal",
-          "serviceName": "app-1-spk-root-service",
-          "services": {
-            "app-1-spk-root-service": {
-              "name": "app-1-spk-root-service",
-              "weight": -1,
-              "ports": {
-                "http": 8090
-              }
-            }
-          },
-          "type": "rollout",
-          "selectors": {
-            "app": "app-1"
-          },
-          "ports": [
-            {
-              "name": "http",
-              "number": 80,
-              "protocol": "http"
-            }
-          ],
-          "trafficPolicy": {
-            "clientConnectionConfig": {
-              "metadata": {
-                "name": "sampleCCC",
-                "labels": {
-                  "identity": "sample"
-                },
-                "annotations": {
-                  "env": "qal"
+        ],
+        "qal": [
+          {
+            "name": "qal",
+            "namespace": "ns-1-usw2-qal",
+            "services": {
+              "app-1-spk-service": {
+                "name": "app-1-spk-service",
+                "weight": -1,
+                "ports": {
+                  "http": 8090
                 }
-              },
-              "spec": {
-                "connectionPool": {
-                  "http": {
-                    "http2MaxRequests": 1000,
-                    "maxRequestsPerConnection": 5
-                  }
-                },
-                "tunnel": {}
               }
             },
-            "globalTrafficPolicy": {
-              "metadata": {
-                "name": "sampleGTP",
-                "labels": {
-                  "identity": "sample"
+            "type": "rollout",
+            "selectors": {
+              "app": "app-1"
+            },
+            "ports": [
+              {
+                "name": "http",
+                "number": 80,
+                "protocol": "http"
+              }
+            ],
+            "trafficPolicy": {
+              "clientConnectionConfig": {
+                "metadata": {
+                  "name": "sampleCCC",
+                  "labels": {
+                    "identity": "sample"
+                  },
+                  "annotations": {
+                    "env": "qal"
+                  }
                 },
-                "annotations": {
-                  "env": "qal"
-                }
-              },
-              "spec": {
-                "policy": [
-                  {
-                    "target": [
-                      {
-                        "region": "us-west-2",
-                        "weight": 50
-                      },
-                      {
-                        "region": "us-east-2",
-                        "weight": 50
-                      }
-                    ],
-                    "dnsPrefix": "testDnsPrefix",
-                    "outlier_detection": {
-                      "consecutive_gateway_errors": 5,
-                      "interval": 5
+                "spec": {
+                  "connectionPool": {
+                    "http": {
+                      "http2MaxRequests": 1000,
+                      "maxRequestsPerConnection": 5
                     }
-                  }
-                ]
-              }
-            },
-            "outlierDetection": {
-              "metadata": {
-                "name": "sampleOD",
-                "labels": {
-                  "identity": "sample"
-                },
-                "annotations": {
-                  "env": "qal"
+                  },
+                  "tunnel": {}
                 }
               },
-              "spec": {
-                "outlier_config": {
-                  "consecutive_gateway_errors": 10,
-                  "interval": 10
+              "globalTrafficPolicy": {
+                "metadata": {
+                  "name": "sampleGTP",
+                  "labels": {
+                    "identity": "sample"
+                  },
+                  "annotations": {
+                    "env": "qal"
+                  }
+                },
+                "spec": {
+                  "policy": [
+                    {
+                      "target": [
+                        {
+                          "region": "us-west-2",
+                          "weight": 50
+                        },
+                        {
+                          "region": "us-east-2",
+                          "weight": 50
+                        }
+                      ],
+                      "dnsPrefix": "testDnsPrefix",
+                      "outlier_detection": {
+                        "consecutive_gateway_errors": 5,
+                        "interval": 5
+                      }
+                    }
+                  ]
+                }
+              },
+              "outlierDetection": {
+                "metadata": {
+                  "name": "sampleOD",
+                  "labels": {
+                    "identity": "sample"
+                  },
+                  "annotations": {
+                    "env": "qal"
+                  }
+                },
+                "spec": {
+                  "outlier_config": {
+                    "consecutive_gateway_errors": 10,
+                    "interval": 10
+                  }
                 }
               }
             }
           }
-        }
+        ]
       }
     }
   },

--- a/admiral/pkg/clusters/util.go
+++ b/admiral/pkg/clusters/util.go
@@ -323,9 +323,11 @@ func getIngressPortName(meshPorts map[string]uint32) string {
 }
 
 func parseWeightedService(weightedServices map[string]*WeightedService) map[string]*registry.RegistryServiceConfig {
+	//TODO: all services with weights need to be added here
 	return nil
 }
 
 func parseMigrationService(services []*k8sV1.Service) map[string]*registry.RegistryServiceConfig {
+	//TODO: both deploy and rellout need to be in the environment config
 	return nil
 }

--- a/admiral/pkg/registry/config.go
+++ b/admiral/pkg/registry/config.go
@@ -17,12 +17,13 @@ func (config *IdentityConfig) PutClusterConfig(name string, clusterConfig Identi
 }
 
 type IdentityConfigCluster struct {
-	Name            string                                `json:"name"`
-	Locality        string                                `json:"locality"`
-	IngressEndpoint string                                `json:"ingressEndpoint"`
-	IngressPort     string                                `json:"ingressPort"`
-	IngressPortName string                                `json:"ingressPortName"`
-	Environment     map[string]*IdentityConfigEnvironment `json:"environment"`
+	Name            string `json:"name"`
+	Locality        string `json:"locality"`
+	IngressEndpoint string `json:"ingressEndpoint"`
+	IngressPort     string `json:"ingressPort"`
+	IngressPortName string `json:"ingressPortName"`
+	// env -> rollout/deploy -> IdentityConfigEnvironment
+	Environment map[string]map[string]*IdentityConfigEnvironment `json:"environment"`
 }
 
 func (config *IdentityConfigCluster) PutEnvironment(name string, environmentConfig IdentityConfigEnvironment) error {
@@ -49,7 +50,7 @@ type IdentityConfigEnvironment struct {
 	Name          string                            `json:"name"`
 	Namespace     string                            `json:"namespace"`
 	Services      map[string]*RegistryServiceConfig `json:"services"`
-	ServiceName   string                            `json:"serviceName"`
+	Strategy      string                            `json:"strategy"`
 	Type          string                            `json:"type"`
 	Selectors     map[string]string                 `json:"selectors"`
 	Ports         []*networking.ServicePort         `json:"ports"`

--- a/admiral/pkg/registry/configSyncer.go
+++ b/admiral/pkg/registry/configSyncer.go
@@ -59,7 +59,7 @@ func (c *configSync) UpdateEnvironmentConfigByCluster(
 			configCache.Clusters[cluster].Locality = clusterConfig.Locality
 			configCache.Clusters[cluster].Name = clusterConfig.Name
 			if configCache.Clusters[cluster].Environment == nil {
-				configCache.Clusters[cluster].Environment = map[string]*IdentityConfigEnvironment{}
+				configCache.Clusters[cluster].Environment = map[string]map[string]*IdentityConfigEnvironment{}
 			}
 			configCache.Clusters[cluster].Environment[environment] = config.Clusters[cluster].Environment[environment]
 			ctxLogger.Infof(common.CtxLogFormat, task, config.IdentityName, "", cluster, "updating the cache")
@@ -72,9 +72,7 @@ func (c *configSync) UpdateEnvironmentConfigByCluster(
 			IngressEndpoint: clusterConfig.IngressEndpoint,
 			IngressPort:     clusterConfig.IngressPort,
 			IngressPortName: clusterConfig.IngressPortName,
-			Environment: map[string]*IdentityConfigEnvironment{
-				environment: clusterConfig.Environment[environment],
-			},
+			Environment:     clusterConfig.Environment,
 		}
 		ctxLogger.Infof(common.CtxLogFormat, task, config.IdentityName, "", cluster, "updating the cache")
 		return cache.Update(config.IdentityName, configCache, writer)

--- a/admiral/pkg/registry/testutils.go
+++ b/admiral/pkg/registry/testutils.go
@@ -9,9 +9,8 @@ import (
 
 func GetSampleIdentityConfigEnvironment(env string, namespace string, identity string) *IdentityConfigEnvironment {
 	identityConfigEnvironment := &IdentityConfigEnvironment{
-		Name:        env,
-		Namespace:   namespace,
-		ServiceName: "app-1-spk-root-service",
+		Name:      env,
+		Namespace: namespace,
 		Services: map[string]*RegistryServiceConfig{
 			"app-1-spk-root-service": {
 				Name:   "app-1-spk-root-service",
@@ -92,10 +91,16 @@ func GetSampleIdentityConfig(identity string) IdentityConfig {
 	prfEnv := GetSampleIdentityConfigEnvironment("prf", "ns-1-usw2-prf", identity)
 	e2eEnv := GetSampleIdentityConfigEnvironment("e2e", "ns-1-usw2-e2e", identity)
 	qalEnv := GetSampleIdentityConfigEnvironment("qal", "ns-1-usw2-qal", identity)
-	environments := map[string]*IdentityConfigEnvironment{
-		"prf": prfEnv,
-		"e2e": e2eEnv,
-		"qal": qalEnv,
+	environments := map[string]map[string]*IdentityConfigEnvironment{
+		"prf": {
+			"rollout": prfEnv,
+		},
+		"e2e": {
+			"rollout": e2eEnv,
+		},
+		"qal": {
+			"rollout": qalEnv,
+		},
 	}
 	clientAssets := map[string]string{
 		"sample": "sample",


### PR DESCRIPTION
Add a "strategy" field instead of "serviceName"
Allow IdentityConfigEnvironment to have multiple deployment/rollouts (change from map[string]*IdentityConfigEnvironment to map[string]*[]IdentityConfigEnvironment
Add a way for state syncer to specify which services are root/stable/desired, preview/desired, ping/pong. -> no change technically here, but in the map of services, key should be root/stable/desire/preview/ping/pong instead of serviceName.

Thank you!