### PR TITLE
generating ingress DR for VS based routing

### DIFF
--- a/admiral/cmd/admiral/cmd/root.go
+++ b/admiral/cmd/admiral/cmd/root.go
@@ -256,6 +256,7 @@ func GetRootCmd(args []string) *cobra.Command {
 	rootCmd.PersistentFlags().BoolVar(&params.EnableVSRouting, "enable_vs_routing", false, "Enable/Disable VS Based Routing")
 	rootCmd.PersistentFlags().StringArrayVar(&params.VSRoutingGateways, "vs_routing_gateways", []string{}, "The PASSTHROUGH gateways to use for VS based routing")
 	rootCmd.PersistentFlags().StringArrayVar(&params.IngressVSExportToNamespaces, "ingress_vs_export_to_namespaces", []string{"istio-system"}, "List of namespaces where the ingress VS should be exported")
+	rootCmd.PersistentFlags().StringVar(&params.IngressLBPolicy, "ingress_lb_policy", "round_robin", "loadbalancer policy for ingress destination rule (round_robin/random/passthrough/least_request)")
 
 	return rootCmd
 }

--- a/admiral/pkg/controller/common/config.go
+++ b/admiral/pkg/controller/common/config.go
@@ -426,6 +426,12 @@ func EnableSWAwareNSCaches() bool {
 	return wrapper.params.EnableSWAwareNSCaches
 }
 
+func GetIngressLBPolicy() string {
+	wrapper.RLock()
+	defer wrapper.RUnlock()
+	return wrapper.params.IngressLBPolicy
+}
+
 func GetIngressVSExportToNamespace() []string {
 	wrapper.RLock()
 	defer wrapper.RUnlock()

--- a/admiral/pkg/controller/common/types.go
+++ b/admiral/pkg/controller/common/types.go
@@ -124,6 +124,7 @@ type AdmiralParams struct {
 	EnableVSRouting             bool
 	VSRoutingGateways           []string
 	IngressVSExportToNamespaces []string
+	IngressLBPolicy             string
 }
 
 func (b AdmiralParams) String() string {

--- a/admiral/pkg/util/constants.go
+++ b/admiral/pkg/util/constants.go
@@ -13,4 +13,6 @@ const (
 	GlobalTrafficPolicy    = "globalTrafficPolicy"
 	OutlierDetection       = "outlierDetection"
 	ClientConnectionConfig = "clientConnectionConfig"
+
+	IstioSystemNamespace = "istio-system"
 )


### PR DESCRIPTION
### Description
What does this change do and why?
Generates the DR which applied to the ingress in order to facilitate VS based cross cluster routing