### PR TITLE
fix casting of slices of services

### DIFF
--- a/admiral/pkg/controller/admiral/controller.go
+++ b/admiral/pkg/controller/admiral/controller.go
@@ -471,6 +471,7 @@ func shouldRetry(ctxLogger *logrus.Entry, ctx context.Context, obj interface{}, 
 		}
 		switch objFromCache.(type) {
 		case []*v1.Service:
+			// ServiceController returns a slice of services from Get() which needs extra processing before casting
 			servicesSlice, _ := objFromCache.([]*v1.Service)
 			latestObjMeta, latestOk = getMatchingServiceFromServiceSlice(objMeta, servicesSlice)
 		default:

--- a/admiral/pkg/controller/admiral/controller_test.go
+++ b/admiral/pkg/controller/admiral/controller_test.go
@@ -2,6 +2,7 @@ package admiral
 
 import (
 	"context"
+	v1 "k8s.io/api/core/v1"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
@@ -166,6 +167,20 @@ func TestShouldRetry(t *testing.T) {
 		ctx                = context.Background()
 		resourceName1      = "resource-name-1"
 		resourceNameSpace1 = "resource-namespace-1"
+		serviceSlice       = []*v1.Service{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName1 + "-canary",
+					Namespace: resourceNameSpace1,
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName1,
+					Namespace: resourceNameSpace1,
+				},
+			},
+		}
 	)
 	testCases := []struct {
 		name                  string
@@ -236,6 +251,21 @@ func TestShouldRetry(t *testing.T) {
 			},
 			delegator:      nil,
 			expectedResult: true,
+		},
+		{
+			name: "Given an update event, " +
+				"When the controller is a service controller, " +
+				"When the controller returns a slice of services from the cache, " +
+				"Then the func should look through the cache for the matching service.",
+			obj: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName1,
+					Namespace: resourceNameSpace1,
+				},
+			},
+			delegator:             NewMockDelegator(),
+			latestObjInKubernetes: interface{}(serviceSlice),
+			expectedResult:        true,
 		},
 	}
 


### PR DESCRIPTION
### Checklist
🚨 Please review this repository's [contribution guidelines](./CONTRIBUTING.md).

- [x] I've read and agree to the project's contribution guidelines.
- [x] I'm requesting to **pull a topic/feature/bugfix branch**.
- [x] I checked that my code additions will pass code linting checks and unit tests.
- [x] I updated unit and integration tests (if applicable).
- [x] I'm ready to notify the team of this contribution.

### Description
Previously, we were attempting to cast []*v1.Service to metav1.Object. This is because the cached services are stored as slices, as each identity could have more than one service. Instead, we check the service that we got the event for against each of the services in the slice to pick the right one in the cache to cast to metav1.Object.

Thank you!