### PR TITLE
[MESH-5509] Ensure Locality Label in Service Entries

### DIFF
--- a/admiral/pkg/clusters/registry.go
+++ b/admiral/pkg/clusters/registry.go
@@ -192,7 +192,7 @@ func (r *RemoteRegistry) createCacheController(clientConfig *rest.Config, cluste
 			return fmt.Errorf("error with OutlierDetectionController initialization, err: %v", err)
 		}
 		logrus.Infof("starting NodeController clusterID: %v", clusterID)
-		rc.NodeController, err = admiral.NewNodeController(stop, &NodeHandler{RemoteRegistry: r, ClusterID: clusterID}, clientConfig, r.ClientLoader)
+		rc.NodeController, err = admiral.NewNodeController(stop, &NodeHandler{RemoteRegistry: r, ClusterID: clusterID}, clientConfig, resyncPeriod.UniversalReconcileInterval, r.ClientLoader)
 		if err != nil {
 			return fmt.Errorf("error with NodeController controller initialization, err: %v", err)
 		}

--- a/admiral/pkg/clusters/registry_test.go
+++ b/admiral/pkg/clusters/registry_test.go
@@ -153,7 +153,7 @@ func createMockRemoteController(f func(interface{})) (*RemoteController, error) 
 	if err != nil {
 		return nil, err
 	}
-	n, err := admiral.NewNodeController(stop, &test.MockNodeHandler{}, &config, loader.GetFakeClientLoader())
+	n, err := admiral.NewNodeController(stop, &test.MockNodeHandler{}, &config, time.Second*time.Duration(300), loader.GetFakeClientLoader())
 	if err != nil {
 		return nil, err
 	}

--- a/admiral/pkg/clusters/serviceentry.go
+++ b/admiral/pkg/clusters/serviceentry.go
@@ -1505,7 +1505,7 @@ func AddServiceEntriesWithDrWorker(
 						util.LogElapsedTimeSinceTask(ctxLogger, "ReconcileServiceEntry", "", "", cluster, "", start)
 
 						valid := validateLocalityInServiceEntry(newServiceEntry)
-						if seReconciliationRequired {
+						if seReconciliationRequired && valid {
 							err = addUpdateServiceEntry(ctxLogger, ctx, newServiceEntry, oldServiceEntry, syncNamespace, rc)
 							addSEorDRToAClusterError = common.AppendError(addSEorDRToAClusterError, err)
 						}

--- a/admiral/pkg/clusters/serviceentry_test.go
+++ b/admiral/pkg/clusters/serviceentry_test.go
@@ -8202,7 +8202,8 @@ func TestAddServiceEntriesWithDrWorker(t *testing.T) {
 		Hosts: []string{"test.mesh"},
 		Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
 			&istioNetworkingV1Alpha3.WorkloadEntry{
-				Address: "aws-lb.1.com",
+				Address:  "aws-lb.1.com",
+				Locality: "us-west-2",
 			},
 		},
 	}
@@ -8210,7 +8211,8 @@ func TestAddServiceEntriesWithDrWorker(t *testing.T) {
 		Hosts: []string{"test-existing-and-desired.mesh"},
 		Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
 			&istioNetworkingV1Alpha3.WorkloadEntry{
-				Address: "aws-lb.1.com",
+				Address:  "aws-lb.1.com",
+				Locality: "us-west-2",
 			},
 		},
 	}
@@ -10062,5 +10064,77 @@ func TestStateSyncerConfiguration(t *testing.T) {
 			}
 			assert.Equal(t, c.assertFunc(), nil)
 		})
+	}
+}
+
+func TestValidateLocalityInServiceEntry(t *testing.T) {
+	testCases := []struct {
+		name     string
+		entry    *v1alpha3.ServiceEntry
+		expected bool
+	}{
+		{
+			"AllEndpointsWithLocality",
+			&v1alpha3.ServiceEntry{
+				Spec: istioNetworkingV1Alpha3.ServiceEntry{
+					Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
+						{Locality: "us-west-2"},
+						{Locality: "us-east-2"},
+					},
+				},
+			},
+			true,
+		},
+		{
+			"NoEndpoints",
+			&v1alpha3.ServiceEntry{
+				Spec: istioNetworkingV1Alpha3.ServiceEntry{
+					Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{},
+				},
+			},
+			true,
+		},
+		{
+			"SingleEndpointLocalitySet",
+			&v1alpha3.ServiceEntry{
+				Spec: istioNetworkingV1Alpha3.ServiceEntry{
+					Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
+						{Locality: "us-west-2"},
+					},
+				},
+			},
+			true,
+		},
+		{
+			"SomeEndpointsMissingLocality",
+			&v1alpha3.ServiceEntry{
+				Spec: istioNetworkingV1Alpha3.ServiceEntry{
+					Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
+						{Locality: "us-west-2"},
+						{Address: "abc.foo.com."},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"AllEndpointsWithoutLocality",
+			&v1alpha3.ServiceEntry{
+				Spec: istioNetworkingV1Alpha3.ServiceEntry{
+					Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
+						{Address: "abc.foo.com."},
+						{Address: "def.foo.com."},
+					},
+				},
+			},
+			false,
+		},
+	}
+
+	for _, tt := range testCases {
+		result := validateLocalityInServiceEntry(tt.entry)
+		if result != tt.expected {
+			t.Errorf("Test failed: %s \nExpected: %v \nGot: %v", tt.name, tt.expected, result)
+		}
 	}
 }

--- a/admiral/pkg/controller/admiral/node.go
+++ b/admiral/pkg/controller/admiral/node.go
@@ -72,7 +72,8 @@ func (d *NodeController) Added(ctx context.Context, obj interface{}) error {
 		return err
 	}
 	if region == "" {
-		return fmt.Errorf("received empty region for node %v", obj)
+		log.Debugf("received empty region for node %v", obj)
+		return nil
 	}
 	d.Locality = &Locality{Region: region}
 	return nil
@@ -84,7 +85,8 @@ func (d *NodeController) Updated(ctx context.Context, obj interface{}, oldObj in
 		return err
 	}
 	if region == "" {
-		return fmt.Errorf("received empty region for node %v", obj)
+		log.Debugf("received empty region for node %v", obj)
+		return nil
 	}
 	d.Locality = &Locality{Region: region}
 	return nil

--- a/admiral/pkg/controller/admiral/node.go
+++ b/admiral/pkg/controller/admiral/node.go
@@ -68,8 +68,11 @@ func process(ctx context.Context, obj interface{}) (string, error) {
 
 func (d *NodeController) Added(ctx context.Context, obj interface{}) error {
 	region, err := process(ctx, obj)
-	if err != nil || region == "" {
+	if err != nil {
 		return err
+	}
+	if region == "" {
+		return fmt.Errorf("received empty region for node %v", obj)
 	}
 	d.Locality = &Locality{Region: region}
 	return nil
@@ -77,8 +80,11 @@ func (d *NodeController) Added(ctx context.Context, obj interface{}) error {
 
 func (d *NodeController) Updated(ctx context.Context, obj interface{}, oldObj interface{}) error {
 	region, err := process(ctx, obj)
-	if err != nil || region == "" {
+	if err != nil {
 		return err
+	}
+	if region == "" {
+		return fmt.Errorf("received empty region for node %v", obj)
 	}
 	d.Locality = &Locality{Region: region}
 	return nil

--- a/admiral/pkg/controller/admiral/node_test.go
+++ b/admiral/pkg/controller/admiral/node_test.go
@@ -59,7 +59,7 @@ func TestNodeAddedTypeAssertion(t *testing.T) {
 				"When Node param is of type *v1.Node with no locality label" +
 				"Then func should return an error",
 			node:          &k8sV1.Node{},
-			expectedError: fmt.Errorf("received empty region for node %v", &k8sV1.Node{}),
+			expectedError: nil,
 		},
 	}
 
@@ -132,9 +132,8 @@ func TestNodeAddUpdateDelete(t *testing.T) {
 
 	// Verify that another update of node without a region label does not change the region
 	nodeObj.Labels = map[string]string{}
-	err = nodeController.Updated(ctx, nodeObj, nodeObj)
+	_ = nodeController.Updated(ctx, nodeObj, nodeObj)
 	assert.Equal(t, "us-east-2", nodeController.Locality.Region, "region expected %v, got: %v", region, nodeController.Locality.Region)
-	assert.Contains(t, err.Error(), "received empty region for node")
 
 	_ = nodeController.Deleted(ctx, nodeObj)
 	//delete should make no difference

--- a/admiral/pkg/controller/admiral/node_test.go
+++ b/admiral/pkg/controller/admiral/node_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/istio-ecosystem/admiral/admiral/pkg/client/loader"
 	"github.com/istio-ecosystem/admiral/admiral/pkg/controller/common"
@@ -75,7 +76,7 @@ func TestNewNodeController(t *testing.T) {
 	stop := make(chan struct{})
 	handler := test.MockNodeHandler{}
 
-	nodeController, err := NewNodeController(stop, &handler, config, loader.GetFakeClientLoader())
+	nodeController, err := NewNodeController(stop, &handler, config, time.Second*time.Duration(300), loader.GetFakeClientLoader())
 
 	if err != nil {
 		t.Errorf("Unexpected err %v", err)
@@ -94,7 +95,7 @@ func TestNodeAddUpdateDelete(t *testing.T) {
 	stop := make(chan struct{})
 	handler := test.MockNodeHandler{}
 
-	nodeController, err := NewNodeController(stop, &handler, config, loader.GetFakeClientLoader())
+	nodeController, err := NewNodeController(stop, &handler, config, time.Second*time.Duration(300), loader.GetFakeClientLoader())
 
 	if err != nil {
 		t.Errorf("Unexpected err %v", err)


### PR DESCRIPTION
- Added `Locality` field to `WorkloadEntry` in `serviceentry_test.go`.
- Implemented `validateLocalityInServiceEntry` function to check locality in service entries.
- Integrated locality validation in service entry reconciliation logic.
- Modified `NewNodeController` to accept `resyncPeriod` parameter.
- Updated tests to reflect changes in `NewNodeController` signature.

### Checklist
🚨 Please review this repository's [contribution guidelines](./CONTRIBUTING.md).

- [x] I've read and agree to the project's contribution guidelines.
- [x] I'm requesting to **pull a topic/feature/bugfix branch**.
- [x] I checked that my code additions will pass code linting checks and unit tests.
- [x] I updated unit and integration tests (if applicable).
- [x] I'm ready to notify the team of this contribution.

### Description
What does this change do and why?

[Link to related ISSUE]

Thank you!