### PR TITLE
[MESH-5465] Add validation and utility functions for identities with partitions

### DIFF
--- a/admiral/pkg/clusters/envoyfilter_test.go
+++ b/admiral/pkg/clusters/envoyfilter_test.go
@@ -263,7 +263,7 @@ func getRegistry(filterVersion string) *RemoteRegistry {
 		DependenciesNamespace:      "default",
 		EnvoyFilterVersion:         filterVersion,
 		Profile:                    common.AdmiralProfileDefault,
-		GatewayAssetAliases:        []string{"Intuit.platform.servicesgateway.servicesgateway", "mock.gateway"},
+		GatewayAssetAliases:        []string{"Org.platform.servicesgateway.servicesgateway", "mock.gateway"},
 	}
 
 	p.LabelSet.WorkloadIdentityKey = "identity"

--- a/admiral/pkg/clusters/envoyfilter_test.go
+++ b/admiral/pkg/clusters/envoyfilter_test.go
@@ -341,18 +341,18 @@ func TestGetWorkloadSelectorLabels(t *testing.T) {
 		{
 			name: "Given gateway asset alias" +
 				"Should create a map containing the partition and original identifier",
-			identifier: "sw1.intuit.platform.servicesgateway.servicesgateway",
+			identifier: "sw1.org.platform.servicesgateway.servicesgateway",
 			expectedList: map[string]string{
 				common.GetPartitionIdentifier(): "sw1",
-				common.AssetAlias:               "Intuit.platform.servicesgateway.servicesgateway",
+				common.AssetAlias:               "Org.platform.servicesgateway.servicesgateway",
 			},
 		},
 		{
 			name: "Given non gateway asset alias" +
 				"Should create a map containing only the asset alias",
-			identifier: "Intuit.platform.services.payment",
+			identifier: "Org.platform.services.payment",
 			expectedList: map[string]string{
-				common.AssetAlias: "Intuit.platform.services.payment",
+				common.AssetAlias: "Org.platform.services.payment",
 			},
 		},
 		{
@@ -366,9 +366,9 @@ func TestGetWorkloadSelectorLabels(t *testing.T) {
 		{
 			name: "Given GW identifier without partition" +
 				"Should create a map containing only the asset alias",
-			identifier: "Intuit.platform.servicesgateway.servicesgateway",
+			identifier: "Org.platform.servicesgateway.servicesgateway",
 			expectedList: map[string]string{
-				common.AssetAlias: "Intuit.platform.servicesgateway.servicesgateway",
+				common.AssetAlias: "Org.platform.servicesgateway.servicesgateway",
 			},
 		},
 	}

--- a/admiral/pkg/controller/common/common.go
+++ b/admiral/pkg/controller/common/common.go
@@ -727,3 +727,23 @@ func GenerateUniqueNameForVS(originNamespace string, vsName string) string {
 	return newVSName
 
 }
+
+func IsAGateway(item string) bool {
+	gwAssetAliases := GetGatewayAssetAliases()
+	for _, gw := range gwAssetAliases {
+		if strings.HasSuffix(strings.ToLower(item), Sep+strings.ToLower(gw)) {
+			return true
+		}
+	}
+	return false
+}
+
+func GetPartitionAndOriginalIdentifierFromPartitionedIdentifier(partitionedIdentifier string) (string, string) {
+	gwAssetAliases := GetGatewayAssetAliases()
+	for _, gw := range gwAssetAliases {
+		if strings.HasSuffix(strings.ToLower(partitionedIdentifier), Sep+strings.ToLower(gw)) {
+			return strings.TrimSuffix(partitionedIdentifier, Sep+strings.ToLower(gw)), gw
+		}
+	}
+	return "", partitionedIdentifier
+}

--- a/admiral/pkg/controller/common/common.go
+++ b/admiral/pkg/controller/common/common.go
@@ -739,6 +739,14 @@ func IsAGateway(item string) bool {
 }
 
 func GetPartitionAndOriginalIdentifierFromPartitionedIdentifier(partitionedIdentifier string) (string, string) {
+	// Given gwAssetAliases = [Org.platform.servicesgateway.servicesgateway], partitionedIdentifier = swx.org.platform.servicesgateway.servicesgateway
+	// returns swx, Org.platform.servicesgateway.servicesgateway
+
+	// Given gwAssetAliases = [Org.platform.servicesgateway.servicesgateway], partitionedIdentifier = Org.platform.servicesgateway.servicesgateway
+	// returns "", Org.platform.servicesgateway.servicesgateway
+
+	// Given gwAssetAliases = [Org.platform.servicesgateway.servicesgateway], partitionedIdentifier = Abc.foo.bar
+	// returns "", Abc.foo.bar
 	gwAssetAliases := GetGatewayAssetAliases()
 	for _, gw := range gwAssetAliases {
 		if strings.HasSuffix(strings.ToLower(partitionedIdentifier), Sep+strings.ToLower(gw)) {

--- a/admiral/pkg/controller/common/common_test.go
+++ b/admiral/pkg/controller/common/common_test.go
@@ -51,6 +51,7 @@ func initConfig(fqdn bool, fqdnLocal bool) {
 		EnableAbsoluteFQDNForLocalEndpoints: fqdnLocal,
 		EnableSWAwareNSCaches:               true,
 		ExportToIdentityList:                []string{"*"},
+		GatewayAssetAliases:                 []string{"mock.gateway", "Intuit.platform.servicesgateway.servicesgateway"},
 	}
 
 	p.LabelSet.WorkloadIdentityKey = "identity"
@@ -1233,6 +1234,85 @@ func TestGenerateUniqueNameForVS(t *testing.T) {
 			iVal := GenerateUniqueNameForVS(c.nsName, c.vsName)
 			if !(iVal == c.expected) {
 				t.Errorf("Wanted value: %s, got: %s", c.expected, iVal)
+			}
+		})
+	}
+}
+
+func TestIsAGateway(t *testing.T) {
+	initConfig(true, true)
+
+	testCases := []struct {
+		name     string
+		asset    string
+		expected bool
+	}{
+		{
+			name: "Given valid GW asset name" +
+				"Should return true",
+			asset:    "sw1.intuit.platform.servicesgateway.servicesgateway",
+			expected: true,
+		},
+		{
+			name: "Given valid asset name that is not GW" +
+				"Should return false",
+			asset:    "foo.bar",
+			expected: false,
+		},
+		{
+			name: "Given nil asset name" +
+				"Should return false",
+			expected: false,
+		},
+	}
+
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+			iVal := IsAGateway(c.asset)
+			if !(iVal == c.expected) {
+				t.Errorf("Wanted value: %t, got: %t", c.expected, iVal)
+			}
+		})
+	}
+}
+
+func TestGetPartitionAndOriginalIdentifierFromPartitionedIdentifier(t *testing.T) {
+	initConfig(true, true)
+
+	testCases := []struct {
+		name                       string
+		identifier                 string
+		expectedPartition          string
+		expectedOriginalIdentifier string
+	}{
+		{
+			name: "Given valid partitioned identifier" +
+				"Should return partition and original identifier",
+			identifier:                 "sw1.intuit.platform.servicesgateway.servicesgateway",
+			expectedPartition:          "sw1",
+			expectedOriginalIdentifier: "Intuit.platform.servicesgateway.servicesgateway",
+		},
+		{
+			name: "Given gateway asset alias" +
+				"Should return partition and original identifier",
+			identifier:                 "Intuit.platform.servicesgateway.servicesgateway",
+			expectedPartition:          "",
+			expectedOriginalIdentifier: "Intuit.platform.servicesgateway.servicesgateway",
+		},
+		{
+			name: "Given non partitioned identifier" +
+				"Should return empty partition and original identifier",
+			identifier:                 "Intuit.foo.bar",
+			expectedPartition:          "",
+			expectedOriginalIdentifier: "Intuit.foo.bar",
+		},
+	}
+
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+			partition, originalIdentifier := GetPartitionAndOriginalIdentifierFromPartitionedIdentifier(c.identifier)
+			if !(partition == c.expectedPartition && originalIdentifier == c.expectedOriginalIdentifier) {
+				t.Errorf("Wanted partition: %s, original identifier: %s, got: %s, %s", c.expectedPartition, c.expectedOriginalIdentifier, partition, originalIdentifier)
 			}
 		})
 	}

--- a/admiral/pkg/controller/common/common_test.go
+++ b/admiral/pkg/controller/common/common_test.go
@@ -51,7 +51,7 @@ func initConfig(fqdn bool, fqdnLocal bool) {
 		EnableAbsoluteFQDNForLocalEndpoints: fqdnLocal,
 		EnableSWAwareNSCaches:               true,
 		ExportToIdentityList:                []string{"*"},
-		GatewayAssetAliases:                 []string{"mock.gateway", "Intuit.platform.servicesgateway.servicesgateway"},
+		GatewayAssetAliases:                 []string{"mock.gateway", "Org.platform.servicesgateway.servicesgateway"},
 	}
 
 	p.LabelSet.WorkloadIdentityKey = "identity"
@@ -1250,7 +1250,7 @@ func TestIsAGateway(t *testing.T) {
 		{
 			name: "Given valid GW asset name" +
 				"Should return true",
-			asset:    "sw1.intuit.platform.servicesgateway.servicesgateway",
+			asset:    "sw1.org.platform.servicesgateway.servicesgateway",
 			expected: true,
 		},
 		{
@@ -1288,23 +1288,23 @@ func TestGetPartitionAndOriginalIdentifierFromPartitionedIdentifier(t *testing.T
 		{
 			name: "Given valid partitioned identifier" +
 				"Should return partition and original identifier",
-			identifier:                 "sw1.intuit.platform.servicesgateway.servicesgateway",
+			identifier:                 "sw1.org.platform.servicesgateway.servicesgateway",
 			expectedPartition:          "sw1",
-			expectedOriginalIdentifier: "Intuit.platform.servicesgateway.servicesgateway",
+			expectedOriginalIdentifier: "Org.platform.servicesgateway.servicesgateway",
 		},
 		{
 			name: "Given gateway asset alias" +
 				"Should return partition and original identifier",
-			identifier:                 "Intuit.platform.servicesgateway.servicesgateway",
+			identifier:                 "Org.platform.servicesgateway.servicesgateway",
 			expectedPartition:          "",
-			expectedOriginalIdentifier: "Intuit.platform.servicesgateway.servicesgateway",
+			expectedOriginalIdentifier: "Org.platform.servicesgateway.servicesgateway",
 		},
 		{
 			name: "Given non partitioned identifier" +
 				"Should return empty partition and original identifier",
-			identifier:                 "Intuit.foo.bar",
+			identifier:                 "Org.foo.bar",
 			expectedPartition:          "",
-			expectedOriginalIdentifier: "Intuit.foo.bar",
+			expectedOriginalIdentifier: "Org.foo.bar",
 		},
 	}
 


### PR DESCRIPTION


- Added `IsAGateway` and `GetPartitionAndOriginalIdentifierFromPartitionedIdentifier` functions in `common.go` to validate and parse gateway asset aliases.
- Introduced `GetWorkloadSelectorLabels` function in `envoyfilter.go` to generate workload selector labels based on asset aliases.
- Updated `constructEnvoyFilterStruct` to use `GetWorkloadSelectorLabels`.
- Added unit tests for the new functions in `common_test.go` and `envoyfilter_test.go`.
- Included `GatewayAssetAliases` in test configurations.

### Checklist
🚨 Please review this repository's [contribution guidelines](./CONTRIBUTING.md).

- [x] I've read and agree to the project's contribution guidelines.
- [x] I'm requesting to **pull a topic/feature/bugfix branch**.
- [x] I checked that my code additions will pass code linting checks and unit tests.
- [x] I updated unit and integration tests (if applicable).
- [x] I'm ready to notify the team of this contribution.

### Description
What does this change do and why?

[Link to related ISSUE]

Thank you!