### PR TITLE
[MESH-5515] Add 'security.istio.io/tlsMode' label to SE endpoints for deployment to rollout migration usecase

### DIFF
--- a/admiral/pkg/clusters/configwriter.go
+++ b/admiral/pkg/clusters/configwriter.go
@@ -125,7 +125,10 @@ func getServiceEntryEndpoints(
 	endpoint := ingressEndpoints[serverCluster]
 	endpoints := []*networkingV1Alpha3.WorkloadEntry{}
 	tmpEp := endpoint.DeepCopy()
-	tmpEp.Labels[typeLabel] = identityConfigEnvironment.Type
+	if tmpEp.Labels == nil {
+		tmpEp.Labels = make(map[string]string)
+	}
+	tmpEp.Labels["security.istio.io/tlsMode"] = "istio"
 	services := []*registry.RegistryServiceConfig{}
 	for _, service := range identityConfigEnvironment.Services {
 		services = append(services, service)

--- a/admiral/pkg/clusters/configwriter_test.go
+++ b/admiral/pkg/clusters/configwriter_test.go
@@ -57,7 +57,7 @@ func createMockServiceEntry(env string, identity string, endpointAddress string,
 		Endpoints: []*networkingV1Alpha3.WorkloadEntry{{Address: endpointAddress,
 			Locality: "us-west-2",
 			Ports:    map[string]uint32{"http": uint32(endpointPort)},
-			Labels:   map[string]string{"security.istio.io/tlsMode": "istio", "type": "rollout"}}},
+			Labels:   map[string]string{"security.istio.io/tlsMode": "istio"}}},
 		WorkloadSelector: nil,
 		ExportTo:         exportTo,
 		SubjectAltNames:  []string{"spiffe://prefix/" + identity},
@@ -146,33 +146,33 @@ func TestGetServiceEntryEndpoints(t *testing.T) {
 		Address:  "def-elb.us-west-2.elb.amazonaws.com.",
 		Locality: "us-west-2",
 		Ports:    map[string]uint32{"http": uint32(15443)},
-		Labels:   map[string]string{"security.istio.io/tlsMode": "istio", "type": "rollout"},
+		Labels:   map[string]string{"security.istio.io/tlsMode": "istio"},
 	}}
 	remoteDeploymentEndpoints := []*networkingV1Alpha3.WorkloadEntry{{
 		Address:  "def-elb.us-west-2.elb.amazonaws.com.",
 		Locality: "us-west-2",
 		Ports:    map[string]uint32{"http": uint32(15443)},
-		Labels:   map[string]string{"security.istio.io/tlsMode": "istio", "type": "deployment"},
+		Labels:   map[string]string{"security.istio.io/tlsMode": "istio"},
 	}}
 	localEndpoints := []*networkingV1Alpha3.WorkloadEntry{{
 		Address:  "app-1-spk-root-service.ns-1-usw2-e2e.svc.cluster.local.",
 		Locality: "us-west-2",
 		Ports:    map[string]uint32{"http": uint32(8090)},
-		Labels:   map[string]string{"security.istio.io/tlsMode": "istio", "type": "rollout"},
+		Labels:   map[string]string{"security.istio.io/tlsMode": "istio"},
 	}}
 	weightedEndpoints := []*networkingV1Alpha3.WorkloadEntry{
 		{
 			Address:  "app-1-spk-desired-service.ns-1-usw2-e2e.svc.cluster.local.",
 			Locality: "us-west-2",
 			Ports:    map[string]uint32{"http": uint32(8090)},
-			Labels:   map[string]string{"security.istio.io/tlsMode": "istio", "type": "rollout"},
+			Labels:   map[string]string{"security.istio.io/tlsMode": "istio"},
 			Weight:   25,
 		},
 		{
 			Address:  "app-1-spk-stable-service.ns-1-usw2-e2e.svc.cluster.local.",
 			Locality: "us-west-2",
 			Ports:    map[string]uint32{"http": uint32(8090)},
-			Labels:   map[string]string{"security.istio.io/tlsMode": "istio", "type": "rollout"},
+			Labels:   map[string]string{"security.istio.io/tlsMode": "istio"},
 			Weight:   75,
 		},
 	}

--- a/admiral/pkg/clusters/destinationrule_handler_test.go
+++ b/admiral/pkg/clusters/destinationrule_handler_test.go
@@ -149,7 +149,7 @@ func TestGetDestinationRule(t *testing.T) {
 	}
 
 	se := &v1alpha3.ServiceEntry{Hosts: []string{"qa.myservice.global"}, Endpoints: []*v1alpha3.WorkloadEntry{
-		{Address: "east.com", Locality: "us-east-2"}, {Address: "west.com", Locality: "us-west-2"},
+		{Address: "east.com", Locality: "us-east-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}}, {Address: "west.com", Locality: "us-west-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
 	}}
 	noGtpDr := v1alpha3.DestinationRule{
 		Host:          "qa.myservice.global",
@@ -442,7 +442,7 @@ func TestGetDestinationRuleActivePassive(t *testing.T) {
 	seSingleEndpoint := &v1alpha3.ServiceEntry{
 		Hosts: []string{"qa.myservice.global"},
 		Endpoints: []*v1alpha3.WorkloadEntry{
-			{Address: "west.com", Locality: "us-west-2"},
+			{Address: "west.com", Locality: "us-west-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
 		}}
 
 	noGtpDrSingleEndpoint := v1alpha3.DestinationRule{
@@ -484,8 +484,8 @@ func TestGetDestinationRuleActivePassive(t *testing.T) {
 	seMultipleEndpoint := &v1alpha3.ServiceEntry{
 		Hosts: []string{"qa.myservice.global"},
 		Endpoints: []*v1alpha3.WorkloadEntry{
-			{Address: "east.com", Locality: "us-east-2"},
-			{Address: "west.com", Locality: "us-west-2"},
+			{Address: "east.com", Locality: "us-east-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
+			{Address: "west.com", Locality: "us-west-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
 		}}
 
 	noGtpDrMultipleEndpointWest := v1alpha3.DestinationRule{
@@ -766,7 +766,7 @@ func TestCalculateDistribution(t *testing.T) {
 	seSingleEndpoint := &v1alpha3.ServiceEntry{
 		Hosts: []string{"qa.myservice.global"},
 		Endpoints: []*v1alpha3.WorkloadEntry{
-			{Address: "west.com", Locality: "us-west-2"},
+			{Address: "west.com", Locality: "us-west-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
 		}}
 
 	singleEndpointDistribution := []*v1alpha3.LocalityLoadBalancerSetting_Distribute{
@@ -778,8 +778,8 @@ func TestCalculateDistribution(t *testing.T) {
 	seMultipleEndpoint := &v1alpha3.ServiceEntry{
 		Hosts: []string{"qa.myservice.global"},
 		Endpoints: []*v1alpha3.WorkloadEntry{
-			{Address: "east.com", Locality: "us-east-2"},
-			{Address: "west.com", Locality: "us-west-2"},
+			{Address: "east.com", Locality: "us-east-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
+			{Address: "west.com", Locality: "us-west-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
 		}}
 
 	multipleEndpointDistribution := []*v1alpha3.LocalityLoadBalancerSetting_Distribute{
@@ -906,19 +906,19 @@ func TestGetOutlierDetection(t *testing.T) {
 	}
 
 	se := &v1alpha3.ServiceEntry{Hosts: []string{"qa.myservice.global"}, Endpoints: []*v1alpha3.WorkloadEntry{
-		{Address: "east.com", Locality: "us-east-2"}, {Address: "west.com", Locality: "us-west-2"},
+		{Address: "east.com", Locality: "us-east-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}}, {Address: "west.com", Locality: "us-west-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
 	}}
 
 	seOneHostRemote := &v1alpha3.ServiceEntry{Hosts: []string{"qa.myservice.global"}, Endpoints: []*v1alpha3.WorkloadEntry{
-		{Address: "east.com", Locality: "us-east-2"},
+		{Address: "east.com", Locality: "us-east-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
 	}}
 
 	seOneHostLocal := &v1alpha3.ServiceEntry{Hosts: []string{"qa.myservice.global"}, Endpoints: []*v1alpha3.WorkloadEntry{
-		{Address: "hello.ns.svc.cluster.local", Locality: "us-east-2"},
+		{Address: "hello.ns.svc.cluster.local", Locality: "us-east-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
 	}}
 
 	seOneHostRemoteIp := &v1alpha3.ServiceEntry{Hosts: []string{"qa.myservice.global"}, Endpoints: []*v1alpha3.WorkloadEntry{
-		{Address: "95.45.25.34", Locality: "us-east-2"},
+		{Address: "95.45.25.34", Locality: "us-east-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
 	}}
 
 	//Struct of test case info. Name is required.

--- a/admiral/pkg/clusters/registry_test.go
+++ b/admiral/pkg/clusters/registry_test.go
@@ -111,7 +111,7 @@ func TestCopyServiceEntry(t *testing.T) {
 func TestCopyEndpoint(t *testing.T) {
 	setupForRegistryTests()
 	se := networking.WorkloadEntry{
-		Address: "127.0.0.1",
+		Address: "127.0.0.1", Labels: map[string]string{"security.istio.io/tlsMode": "istio"},
 	}
 
 	r := copyEndpoint(&se)

--- a/admiral/pkg/clusters/serviceentry.go
+++ b/admiral/pkg/clusters/serviceentry.go
@@ -1504,7 +1504,7 @@ func AddServiceEntriesWithDrWorker(
 							compareLabels)
 						util.LogElapsedTimeSinceTask(ctxLogger, "ReconcileServiceEntry", "", "", cluster, "", start)
 
-						valid, validityError := validateServiceEntry(newServiceEntry)
+						valid, validityError := validateServiceEntryEndpoints(newServiceEntry)
 						if seReconciliationRequired && valid && validityError == nil {
 							err = addUpdateServiceEntry(ctxLogger, ctx, newServiceEntry, oldServiceEntry, syncNamespace, rc)
 							addSEorDRToAClusterError = common.AppendError(addSEorDRToAClusterError, err)
@@ -1610,7 +1610,7 @@ func AddServiceEntriesWithDrWorker(
 	}
 }
 
-func validateServiceEntry(entry *v1alpha3.ServiceEntry) (bool, error) {
+func validateServiceEntryEndpoints(entry *v1alpha3.ServiceEntry) (bool, error) {
 	// loop through all endpoints and check locality and istio mode labels
 	var errorStrings []string
 

--- a/admiral/pkg/clusters/serviceentry.go
+++ b/admiral/pkg/clusters/serviceentry.go
@@ -1504,14 +1504,14 @@ func AddServiceEntriesWithDrWorker(
 							compareLabels)
 						util.LogElapsedTimeSinceTask(ctxLogger, "ReconcileServiceEntry", "", "", cluster, "", start)
 
-						valid := validateLocalityInServiceEntry(newServiceEntry)
-						if seReconciliationRequired && valid {
+						valid, validityError := validateServiceEntry(newServiceEntry)
+						if seReconciliationRequired && valid && validityError == nil {
 							err = addUpdateServiceEntry(ctxLogger, ctx, newServiceEntry, oldServiceEntry, syncNamespace, rc)
 							addSEorDRToAClusterError = common.AppendError(addSEorDRToAClusterError, err)
 						}
-						if !valid {
-							ctxLogger.Errorf(LogErrFormat, "ValidateLocalityInServiceEntry", "", seDr.SeName, cluster, "failed to validate locality in service entry")
-							addSEorDRToAClusterError = common.AppendError(addSEorDRToAClusterError, fmt.Errorf("failed to validate locality in service entry"))
+						if !valid || validityError != nil {
+							ctxLogger.Errorf(LogErrFormat, "ValidateLocalityInServiceEntry", "", seDr.SeName, cluster, fmt.Errorf("failed to validate the service entry, received error: %v", validityError))
+							addSEorDRToAClusterError = common.AppendError(addSEorDRToAClusterError, fmt.Errorf("failed to validate locality in service entry, received error: %v", validityError))
 						}
 						util.LogElapsedTimeSinceTask(ctxLogger, "AdmiralCacheAddUpdateServiceEntry", "", "", cluster, "", start) // TODO: log service entry name
 
@@ -1610,14 +1610,24 @@ func AddServiceEntriesWithDrWorker(
 	}
 }
 
-func validateLocalityInServiceEntry(entry *v1alpha3.ServiceEntry) bool {
-	// loop through all endpoints and check locality
+func validateServiceEntry(entry *v1alpha3.ServiceEntry) (bool, error) {
+	// loop through all endpoints and check locality and istio mode labels
+	var errorStrings []string
+
 	for _, ep := range entry.Spec.Endpoints {
 		if ep.Locality == "" {
-			return false
+			errorStrings = append(errorStrings, fmt.Sprintf("locality not set for endpoint with address %s", ep.Address))
+		}
+		if ep.Labels == nil || ep.Labels["security.istio.io/tlsMode"] != "istio" {
+			errorStrings = append(errorStrings, fmt.Sprintf("istio mode not set for endpoint with address %s", ep.Address))
 		}
 	}
-	return true
+
+	if len(errorStrings) > 0 {
+		return false, fmt.Errorf(strings.Join(errorStrings, ", "))
+	}
+
+	return true, nil
 }
 
 func getClusterRegion(rr *RemoteRegistry, cluster string, rc *RemoteController) (string, error) {

--- a/admiral/pkg/clusters/serviceentry_handler_test.go
+++ b/admiral/pkg/clusters/serviceentry_handler_test.go
@@ -38,8 +38,8 @@ func TestSkipDestructiveUpdate(t *testing.T) {
 		Resolution:      v1alpha3.ServiceEntry_DNS,
 		SubjectAltNames: []string{"spiffe://prefix/my-first-service"},
 		Endpoints: []*v1alpha3.WorkloadEntry{
-			{Address: "dummy.admiral.global-west", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2"},
-			{Address: "dummy.admiral.global-east", Ports: map[string]uint32{"http": 0}, Locality: "us-east-2"},
+			{Address: "dummy.admiral.global-west", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
+			{Address: "dummy.admiral.global-east", Ports: map[string]uint32{"http": 0}, Locality: "us-east-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
 		},
 	}
 	twoEndpointSeUpdated := v1alpha3.ServiceEntry{
@@ -51,8 +51,8 @@ func TestSkipDestructiveUpdate(t *testing.T) {
 		Resolution:      v1alpha3.ServiceEntry_DNS,
 		SubjectAltNames: []string{"spiffe://prefix/my-first-service"},
 		Endpoints: []*v1alpha3.WorkloadEntry{
-			{Address: "dummy.admiral.global-west", Ports: map[string]uint32{"http": 90}, Locality: "us-west-2"},
-			{Address: "dummy.admiral.global-east", Ports: map[string]uint32{"http": 0}, Locality: "us-east-2"},
+			{Address: "dummy.admiral.global-west", Ports: map[string]uint32{"http": 90}, Locality: "us-west-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
+			{Address: "dummy.admiral.global-east", Ports: map[string]uint32{"http": 0}, Locality: "us-east-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
 		},
 	}
 	oneEndpointSe := v1alpha3.ServiceEntry{
@@ -64,7 +64,7 @@ func TestSkipDestructiveUpdate(t *testing.T) {
 		Resolution:      v1alpha3.ServiceEntry_DNS,
 		SubjectAltNames: []string{"spiffe://prefix/my-first-service"},
 		Endpoints: []*v1alpha3.WorkloadEntry{
-			{Address: "dummy.admiral.global-west", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2"},
+			{Address: "dummy.admiral.global-west", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
 		},
 	}
 	newSeTwoEndpoints := &v1alpha32.ServiceEntry{
@@ -196,8 +196,8 @@ func TestAddUpdateServiceEntry(t *testing.T) {
 		Resolution:      v1alpha3.ServiceEntry_DNS,
 		SubjectAltNames: []string{"spiffe://prefix/my-first-service"},
 		Endpoints: []*v1alpha3.WorkloadEntry{
-			{Address: "dummy.admiral.global-west", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2"},
-			{Address: "dummy.admiral.global-east", Ports: map[string]uint32{"http": 0}, Locality: "us-east-2"},
+			{Address: "dummy.admiral.global-west", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
+			{Address: "dummy.admiral.global-east", Ports: map[string]uint32{"http": 0}, Locality: "us-east-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
 		},
 	}
 
@@ -210,7 +210,7 @@ func TestAddUpdateServiceEntry(t *testing.T) {
 		Resolution:      v1alpha3.ServiceEntry_DNS,
 		SubjectAltNames: []string{"spiffe://prefix/my-first-service"},
 		Endpoints: []*v1alpha3.WorkloadEntry{
-			{Address: "dummy.admiral.global-west", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2"},
+			{Address: "dummy.admiral.global-west", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
 		},
 	}
 
@@ -223,8 +223,8 @@ func TestAddUpdateServiceEntry(t *testing.T) {
 		Resolution:      v1alpha3.ServiceEntry_DNS,
 		SubjectAltNames: []string{"spiffe://prefix/my-first-service"},
 		Endpoints: []*v1alpha3.WorkloadEntry{
-			{Address: "dummy.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2"},
-			{Address: "test.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-east-2"},
+			{Address: "dummy.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
+			{Address: "test.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-east-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
 		},
 	}
 
@@ -340,21 +340,21 @@ func TestAddUpdateServiceEntry(t *testing.T) {
 
 func TestValidateServiceEntryEndpoints(t *testing.T) {
 	twoValidEndpoints := []*v1alpha3.WorkloadEntry{
-		{Address: "valid1.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2"},
-		{Address: "valid2.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-east-2"},
+		{Address: "valid1.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
+		{Address: "valid2.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-east-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
 	}
 
 	oneValidEndpoints := []*v1alpha3.WorkloadEntry{
-		{Address: "valid1.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2"},
+		{Address: "valid1.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
 	}
 
 	dummyEndpoints := []*v1alpha3.WorkloadEntry{
-		{Address: "dummy.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2"},
+		{Address: "dummy.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
 	}
 
 	validAndInvalidEndpoints := []*v1alpha3.WorkloadEntry{
-		{Address: "dummy.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2"},
-		{Address: "valid2.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-east-2"},
+		{Address: "dummy.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
+		{Address: "valid2.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-east-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
 	}
 
 	twoValidEndpointsSe := &v1alpha32.ServiceEntry{
@@ -430,22 +430,22 @@ func TestValidateServiceEntryEndpoints(t *testing.T) {
 			name:                      "Validate SE with valid endpoint",
 			serviceEntry:              oneValidEndpointsSe,
 			expectedAreEndpointsValid: true,
-			expectedValidEndpoints:    []*v1alpha3.WorkloadEntry{{Address: "valid1.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2"}},
+			expectedValidEndpoints:    []*v1alpha3.WorkloadEntry{{Address: "valid1.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}}},
 		},
 		{
 			name:                      "Validate endpoint with multiple valid endpoints",
 			serviceEntry:              twoValidEndpointsSe,
 			expectedAreEndpointsValid: true,
 			expectedValidEndpoints: []*v1alpha3.WorkloadEntry{
-				{Address: "valid1.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2"},
-				{Address: "valid2.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-east-2"}},
+				{Address: "valid1.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
+				{Address: "valid2.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-east-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}}},
 		},
 		{
 			name:                      "Validate endpoint with mix of valid and dummy endpoints",
 			serviceEntry:              validAndInvalidEndpointsSe,
 			expectedAreEndpointsValid: false,
 			expectedValidEndpoints: []*v1alpha3.WorkloadEntry{
-				{Address: "valid2.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-east-2"}},
+				{Address: "valid2.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-east-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}}},
 		},
 	}
 

--- a/admiral/pkg/clusters/serviceentry_od_test.go
+++ b/admiral/pkg/clusters/serviceentry_od_test.go
@@ -173,6 +173,7 @@ func Test_modifyServiceEntryForNewServiceOrPodForOutlierDetection(t *testing.T) 
 							"http": 0,
 						},
 						Locality: "us-west-2",
+						Labels:   map[string]string{"security.istio.io/tlsMode": "istio"},
 					},
 				},
 				SubjectAltNames: []string{"spiffe://prefix/" + deployment1Identity},

--- a/admiral/pkg/clusters/serviceentry_test.go
+++ b/admiral/pkg/clusters/serviceentry_test.go
@@ -225,6 +225,7 @@ func TestModifyServiceEntryForNewServiceOrPodForServiceEntryUpdateSuspension(t *
 							"http": 0,
 						},
 						Locality: "us-west-2",
+						Labels:   map[string]string{"security.istio.io/tlsMode": "istio"},
 					},
 				},
 				SubjectAltNames: []string{"spiffe://prefix/" + deployment1Identity},
@@ -968,42 +969,42 @@ func TestAddServiceEntriesWithDr(t *testing.T) {
 		Hosts:     []string{"sw01.e2e.foo.global"},
 		Addresses: []string{"240.0.0.1"},
 		Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
-			{Address: "127.0.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{}, Network: "mesh1", Locality: "us-west", Weight: 100},
+			{Address: "127.0.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{"security.istio.io/tlsMode": "istio"}, Network: "mesh1", Locality: "us-west", Weight: 100},
 		},
 	}
 
 	newSE := istioNetworkingV1Alpha3.ServiceEntry{
 		Hosts: []string{"dev.newse.global"},
 		Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
-			{Address: "127.0.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{}, Network: "mesh1", Locality: "us-west", Weight: 100},
+			{Address: "127.0.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{"security.istio.io/tlsMode": "istio"}, Network: "mesh1", Locality: "us-west", Weight: 100},
 		},
 	}
 
 	newCanarySE := istioNetworkingV1Alpha3.ServiceEntry{
 		Hosts: []string{"canary.dev.newse.global"},
 		Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
-			{Address: "127.0.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{}, Network: "mesh1", Locality: "us-west", Weight: 100},
+			{Address: "127.0.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{"security.istio.io/tlsMode": "istio"}, Network: "mesh1", Locality: "us-west", Weight: 100},
 		},
 	}
 
 	newSeWithEmptyHosts := istioNetworkingV1Alpha3.ServiceEntry{
 		Hosts: []string{},
 		Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
-			{Address: "127.0.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{}, Network: "mesh1", Locality: "us-west", Weight: 100},
+			{Address: "127.0.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{"security.istio.io/tlsMode": "istio"}, Network: "mesh1", Locality: "us-west", Weight: 100},
 		},
 	}
 
 	newPreviewSE := istioNetworkingV1Alpha3.ServiceEntry{
 		Hosts: []string{"preview.dev.newse.global"},
 		Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
-			{Address: "127.0.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{}, Network: "mesh1", Locality: "us-west", Weight: 100},
+			{Address: "127.0.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{"security.istio.io/tlsMode": "istio"}, Network: "mesh1", Locality: "us-west", Weight: 100},
 		},
 	}
 	newPrefixedSE := istioNetworkingV1Alpha3.ServiceEntry{
 		Addresses: []string{"240.10.1.0"},
 		Hosts:     []string{"e2e.foo.global"},
 		Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
-			{Address: "127.0.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{}, Network: "mesh1", Locality: "us-west", Weight: 100},
+			{Address: "127.0.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{"security.istio.io/tlsMode": "istio"}, Network: "mesh1", Locality: "us-west", Weight: 100},
 		},
 	}
 
@@ -1011,7 +1012,7 @@ func TestAddServiceEntriesWithDr(t *testing.T) {
 		Addresses: []string{"240.10.1.0"},
 		Hosts:     []string{"e2e.bar.global"},
 		Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
-			{Address: "127.0.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{}, Network: "mesh1", Locality: "us-west", Weight: 100},
+			{Address: "127.0.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{"security.istio.io/tlsMode": "istio"}, Network: "mesh1", Locality: "us-west", Weight: 100},
 		},
 	}
 
@@ -1019,7 +1020,7 @@ func TestAddServiceEntriesWithDr(t *testing.T) {
 		Addresses: []string{"240.10.1.0"},
 		Hosts:     []string{"canary.e2e.bar.global"},
 		Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
-			{Address: "127.0.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{}, Network: "mesh1", Locality: "us-west", Weight: 100},
+			{Address: "127.0.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{"security.istio.io/tlsMode": "istio"}, Network: "mesh1", Locality: "us-west", Weight: 100},
 		},
 	}
 
@@ -1027,14 +1028,14 @@ func TestAddServiceEntriesWithDr(t *testing.T) {
 		Addresses: []string{"240.10.1.0"},
 		Hosts:     []string{"canary.e2e.bar1.global"},
 		Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
-			{Address: "127.0.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{}, Network: "mesh1", Locality: "us-west", Weight: 100},
+			{Address: "127.0.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{"security.istio.io/tlsMode": "istio"}, Network: "mesh1", Locality: "us-west", Weight: 100},
 		},
 	}
 
 	se := istioNetworkingV1Alpha3.ServiceEntry{
 		Hosts: []string{"dev.bar.global"},
 		Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
-			{Address: "127.0.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{}, Network: "mesh1", Locality: "us-west", Weight: 100},
+			{Address: "127.0.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{"security.istio.io/tlsMode": "istio"}, Network: "mesh1", Locality: "us-west", Weight: 100},
 		},
 	}
 
@@ -1046,14 +1047,14 @@ func TestAddServiceEntriesWithDr(t *testing.T) {
 	dummyEndpointSe := istioNetworkingV1Alpha3.ServiceEntry{
 		Hosts: []string{"dev.dummy.global"},
 		Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
-			{Address: "dummy.admiral.global", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{}, Network: "mesh1", Locality: "us-west", Weight: 100},
+			{Address: "dummy.admiral.global", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{"security.istio.io/tlsMode": "istio"}, Network: "mesh1", Locality: "us-west", Weight: 100},
 		},
 	}
 
 	dummyEndpointSeForNonSourceCluster := istioNetworkingV1Alpha3.ServiceEntry{
 		Hosts: []string{"dev.dummy.non.source.global"},
 		Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
-			{Address: "dummy.admiral.global", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{}, Network: "mesh1", Locality: "us-west", Weight: 100},
+			{Address: "dummy.admiral.global", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{"security.istio.io/tlsMode": "istio"}, Network: "mesh1", Locality: "us-west", Weight: 100},
 		},
 	}
 
@@ -1068,6 +1069,7 @@ func TestAddServiceEntriesWithDr(t *testing.T) {
 					Network:  "mesh1",
 					Locality: "us-west",
 					Weight:   100,
+					Labels:   map[string]string{"security.istio.io/tlsMode": "istio"},
 				},
 			},
 		},
@@ -1089,6 +1091,7 @@ func TestAddServiceEntriesWithDr(t *testing.T) {
 					Network:  "mesh1",
 					Locality: "us-west",
 					Weight:   100,
+					Labels:   map[string]string{"security.istio.io/tlsMode": "istio"},
 				},
 			},
 		},
@@ -1812,7 +1815,7 @@ func TestAddServiceEntriesWithDrWithoutDatabaseClient(t *testing.T) {
 	dummyEndpointSe := istioNetworkingV1Alpha3.ServiceEntry{
 		Hosts: []string{"dev.dummy.global"},
 		Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
-			{Address: "dummy.admiral.global", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{}, Network: "mesh1", Locality: "us-west", Weight: 100},
+			{Address: "dummy.admiral.global", Ports: map[string]uint32{"https": 80}, Network: "mesh1", Locality: "us-west", Weight: 100, Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
 		},
 	}
 
@@ -1830,7 +1833,7 @@ func TestAddServiceEntriesWithDrWithoutDatabaseClient(t *testing.T) {
 		Addresses: []string{"240.10.1.0"},
 		Hosts:     []string{"e2e.bar.global"},
 		Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
-			{Address: "dummy.admiral.global", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{}, Network: "mesh1", Locality: "us-west", Weight: 100},
+			{Address: "dummy.admiral.global", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{"security.istio.io/tlsMode": "istio"}, Network: "mesh1", Locality: "us-west", Weight: 100},
 		},
 	}
 
@@ -2039,8 +2042,8 @@ func TestCreateSeAndDrSetFromGtp(t *testing.T) {
 		Addresses: []string{"240.10.1.0"},
 		Hosts:     []string{host},
 		Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
-			{Address: "127.0.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{}, Locality: "us-west-2"},
-			{Address: "240.20.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{}, Locality: "us-east-2"},
+			{Address: "127.0.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{"security.istio.io/tlsMode": "istio"}, Locality: "us-west-2"},
+			{Address: "240.20.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{"security.istio.io/tlsMode": "istio"}, Locality: "us-east-2"},
 		},
 	}
 
@@ -2048,8 +2051,8 @@ func TestCreateSeAndDrSetFromGtp(t *testing.T) {
 		Addresses: []string{"240.10.1.0"},
 		Hosts:     []string{hostCanary},
 		Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
-			{Address: "127.0.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{}, Locality: "us-west-2"},
-			{Address: "240.20.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{}, Locality: "us-east-2"},
+			{Address: "127.0.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{"security.istio.io/tlsMode": "istio"}, Locality: "us-west-2"},
+			{Address: "240.20.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{"security.istio.io/tlsMode": "istio"}, Locality: "us-east-2"},
 		},
 	}
 
@@ -2057,8 +2060,8 @@ func TestCreateSeAndDrSetFromGtp(t *testing.T) {
 		Hosts:     []string{"test.bar.mesh"},
 		Addresses: []string{"240.0.10.11"},
 		Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
-			{Address: "127.0.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{}, Locality: "us-west-2"},
-			{Address: "240.20.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{}, Locality: "us-east-2"},
+			{Address: "127.0.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{"security.istio.io/tlsMode": "istio"}, Locality: "us-west-2"},
+			{Address: "240.20.0.1", Ports: map[string]uint32{"https": 80}, Labels: map[string]string{"security.istio.io/tlsMode": "istio"}, Locality: "us-east-2"},
 		},
 	}
 
@@ -2473,6 +2476,7 @@ func TestModifyServiceEntryForNewServiceOrPod(t *testing.T) {
 							"http": 0,
 						},
 						Locality: "us-west-2",
+						Labels:   map[string]string{"security.istio.io/tlsMode": "istio"},
 					},
 				},
 				SubjectAltNames: []string{"spiffe://prefix/" + deployment1Identity},
@@ -3907,7 +3911,7 @@ func TestUpdateEndpointsForBlueGreen(t *testing.T) {
 	rollout.Spec.Template.Annotations[common.SidecarEnabledPorts] = "8080"
 
 	endpoint := &istioNetworkingV1Alpha3.WorkloadEntry{
-		Labels: map[string]string{}, Address: CLUSTER_INGRESS_1, Ports: map[string]uint32{"http": 15443},
+		Labels: map[string]string{"security.istio.io/tlsMode": "istio"}, Address: CLUSTER_INGRESS_1, Ports: map[string]uint32{"http": 15443},
 	}
 
 	meshPorts := map[string]uint32{"http": 8080}
@@ -3918,11 +3922,11 @@ func TestUpdateEndpointsForBlueGreen(t *testing.T) {
 	}
 
 	activeWantedEndpoints := &istioNetworkingV1Alpha3.WorkloadEntry{
-		Address: ACTIVE_SERVICE + common.Sep + NAMESPACE + common.GetLocalDomainSuffix(), Ports: meshPorts,
+		Address: ACTIVE_SERVICE + common.Sep + NAMESPACE + common.GetLocalDomainSuffix(), Ports: meshPorts, Labels: map[string]string{"security.istio.io/tlsMode": "istio"},
 	}
 
 	previewWantedEndpoints := &istioNetworkingV1Alpha3.WorkloadEntry{
-		Address: PREVIEW_SERVICE + common.Sep + NAMESPACE + common.GetLocalDomainSuffix(), Ports: meshPorts,
+		Address: PREVIEW_SERVICE + common.Sep + NAMESPACE + common.GetLocalDomainSuffix(), Ports: meshPorts, Labels: map[string]string{"security.istio.io/tlsMode": "istio"},
 	}
 
 	testCases := []struct {
@@ -3976,8 +3980,8 @@ func TestUpdateEndpointsForWeightedServices(t *testing.T) {
 
 	se := &istioNetworkingV1Alpha3.ServiceEntry{
 		Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
-			{Labels: map[string]string{}, Address: CLUSTER_INGRESS_1, Weight: 10, Ports: map[string]uint32{"http": 15443}},
-			{Labels: map[string]string{}, Address: CLUSTER_INGRESS_2, Weight: 10, Ports: map[string]uint32{"http": 15443}},
+			{Labels: map[string]string{"security.istio.io/tlsMode": "istio"}, Address: CLUSTER_INGRESS_1, Weight: 10, Ports: map[string]uint32{"http": 15443}},
+			{Labels: map[string]string{"security.istio.io/tlsMode": "istio"}, Address: CLUSTER_INGRESS_2, Weight: 10, Ports: map[string]uint32{"http": 15443}},
 		},
 	}
 
@@ -3993,14 +3997,14 @@ func TestUpdateEndpointsForWeightedServices(t *testing.T) {
 	}
 
 	wantedEndpoints := []*istioNetworkingV1Alpha3.WorkloadEntry{
-		{Address: CLUSTER_INGRESS_2, Weight: 10, Ports: map[string]uint32{"http": 15443}},
-		{Address: STABLE_SERVICE + common.Sep + NAMESPACE + common.GetLocalDomainSuffix(), Weight: 90, Ports: meshPorts},
-		{Address: CANARY_SERVICE + common.Sep + NAMESPACE + common.GetLocalDomainSuffix(), Weight: 10, Ports: meshPorts},
+		{Address: CLUSTER_INGRESS_2, Weight: 10, Ports: map[string]uint32{"http": 15443}, Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
+		{Address: STABLE_SERVICE + common.Sep + NAMESPACE + common.GetLocalDomainSuffix(), Weight: 90, Ports: meshPorts, Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
+		{Address: CANARY_SERVICE + common.Sep + NAMESPACE + common.GetLocalDomainSuffix(), Weight: 10, Ports: meshPorts, Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
 	}
 
 	wantedEndpointsZeroWeights := []*istioNetworkingV1Alpha3.WorkloadEntry{
-		{Address: CLUSTER_INGRESS_2, Weight: 10, Ports: map[string]uint32{"http": 15443}},
-		{Address: STABLE_SERVICE + common.Sep + NAMESPACE + common.GetLocalDomainSuffix(), Weight: 100, Ports: meshPorts},
+		{Address: CLUSTER_INGRESS_2, Weight: 10, Ports: map[string]uint32{"http": 15443}, Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
+		{Address: STABLE_SERVICE + common.Sep + NAMESPACE + common.GetLocalDomainSuffix(), Weight: 100, Ports: meshPorts, Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
 	}
 
 	testCases := []struct {
@@ -5576,6 +5580,7 @@ func TestGetWorkloadData(t *testing.T) {
 					Network:  "mesh1",
 					Locality: "us-west",
 					Weight:   100,
+					Labels:   map[string]string{"security.istio.io/tlsMode": "istio"},
 				},
 			},
 		},
@@ -5820,6 +5825,7 @@ func TestGetWorkloadDataActivePassiveEnabled(t *testing.T) {
 					Network:  "mesh1",
 					Locality: "us-west",
 					Weight:   100,
+					Labels:   map[string]string{"security.istio.io/tlsMode": "istio"},
 				},
 			},
 		},
@@ -6231,7 +6237,7 @@ func TestDeployRolloutMigration(t *testing.T) {
 						Ports: map[string]uint32{
 							"http": 8090,
 						},
-						Labels:   map[string]string{"type": common.Deployment},
+						Labels:   map[string]string{"type": common.Deployment, "security.istio.io/tlsMode": "istio"},
 						Locality: "us-west-2",
 					},
 					{
@@ -6239,7 +6245,7 @@ func TestDeployRolloutMigration(t *testing.T) {
 						Ports: map[string]uint32{
 							"http": 8090,
 						},
-						Labels:   map[string]string{"type": common.Rollout},
+						Labels:   map[string]string{"type": common.Rollout, "security.istio.io/tlsMode": "istio"},
 						Locality: "us-west-2",
 					},
 				},
@@ -6599,7 +6605,8 @@ func TestReconcileServiceEntry(t *testing.T) {
 					"http": 15443,
 				},
 				Labels: map[string]string{
-					"deployment": "deployment",
+					"deployment":                "deployment",
+					"security.istio.io/tlsMode": "istio",
 				},
 				Locality: "us-east-2",
 			},
@@ -6609,7 +6616,8 @@ func TestReconcileServiceEntry(t *testing.T) {
 					"http": 15443,
 				},
 				Labels: map[string]string{
-					"deployment": "deployment",
+					"deployment":                "deployment",
+					"security.istio.io/tlsMode": "istio",
 				},
 				Locality: "us-west-2",
 			},
@@ -6626,7 +6634,8 @@ func TestReconcileServiceEntry(t *testing.T) {
 					"http": 15443,
 				},
 				Labels: map[string]string{
-					"deployment": "deployment",
+					"deployment":                "deployment",
+					"security.istio.io/tlsMode": "istio",
 				},
 				Locality: "us-west-2",
 			},
@@ -6636,7 +6645,8 @@ func TestReconcileServiceEntry(t *testing.T) {
 					"http": 15443,
 				},
 				Labels: map[string]string{
-					"deployment": "deployment",
+					"deployment":                "deployment",
+					"security.istio.io/tlsMode": "istio",
 				},
 				Locality: "us-east-2",
 			},
@@ -8204,6 +8214,7 @@ func TestAddServiceEntriesWithDrWorker(t *testing.T) {
 			&istioNetworkingV1Alpha3.WorkloadEntry{
 				Address:  "aws-lb.1.com",
 				Locality: "us-west-2",
+				Labels:   map[string]string{"security.istio.io/tlsMode": "istio"},
 			},
 		},
 	}
@@ -10069,21 +10080,23 @@ func TestStateSyncerConfiguration(t *testing.T) {
 
 func TestValidateLocalityInServiceEntry(t *testing.T) {
 	testCases := []struct {
-		name     string
-		entry    *v1alpha3.ServiceEntry
-		expected bool
+		name        string
+		entry       *v1alpha3.ServiceEntry
+		expected    bool
+		expectedErr interface{}
 	}{
 		{
 			"AllEndpointsWithLocality",
 			&v1alpha3.ServiceEntry{
 				Spec: istioNetworkingV1Alpha3.ServiceEntry{
 					Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
-						{Locality: "us-west-2"},
-						{Locality: "us-east-2"},
+						{Locality: "us-west-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
+						{Locality: "us-east-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
 					},
 				},
 			},
 			true,
+			nil,
 		},
 		{
 			"NoEndpoints",
@@ -10093,32 +10106,35 @@ func TestValidateLocalityInServiceEntry(t *testing.T) {
 				},
 			},
 			true,
+			nil,
 		},
 		{
 			"SingleEndpointLocalitySet",
 			&v1alpha3.ServiceEntry{
 				Spec: istioNetworkingV1Alpha3.ServiceEntry{
 					Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
-						{Locality: "us-west-2"},
+						{Locality: "us-west-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
 					},
 				},
 			},
 			true,
+			nil,
 		},
 		{
 			"SomeEndpointsMissingLocality",
 			&v1alpha3.ServiceEntry{
 				Spec: istioNetworkingV1Alpha3.ServiceEntry{
 					Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
-						{Locality: "us-west-2"},
-						{Address: "abc.foo.com."},
+						{Locality: "us-west-2", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
+						{Address: "abc.foo.com.", Labels: map[string]string{"security.istio.io/tlsMode": "istio"}},
 					},
 				},
 			},
 			false,
+			[]string{"locality not set for endpoint with address abc.foo.com."},
 		},
 		{
-			"AllEndpointsWithoutLocality",
+			"AllEndpointsWithoutLocalityAndMode",
 			&v1alpha3.ServiceEntry{
 				Spec: istioNetworkingV1Alpha3.ServiceEntry{
 					Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
@@ -10128,13 +10144,60 @@ func TestValidateLocalityInServiceEntry(t *testing.T) {
 				},
 			},
 			false,
+			[]string{"locality not set for endpoint with address abc.foo.com.", "istio mode not set for endpoint with address abc.foo.com.", "locality not set for endpoint with address def.foo.com.", "istio mode not set for endpoint with address def.foo.com."},
+		},
+		{
+			"AllEndpointsWithLocalityWithoutIstioModeLabel",
+			&v1alpha3.ServiceEntry{
+				Spec: istioNetworkingV1Alpha3.ServiceEntry{
+					Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
+						{Address: "abc.foo.com.", Locality: "us-west-2"},
+						{Address: "def.foo.com.", Locality: "us-east-2"},
+					},
+				},
+			},
+			false,
+			[]string{"istio mode not set for endpoint with address abc.foo.com.", "istio mode not set for endpoint with address def.foo.com."},
+		},
+		{
+			"AllEndpointsWithLocalityWithPartiallyIstioModeLabel",
+			&v1alpha3.ServiceEntry{
+				Spec: istioNetworkingV1Alpha3.ServiceEntry{
+					Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
+						{Address: "abc.foo.com.", Locality: "us-west-2", Labels: map[string]string{"type": common.Rollout, "security.istio.io/tlsMode": "istio"}},
+						{Address: "def.foo.com.", Locality: "us-east-2"},
+					},
+				},
+			},
+			false,
+			[]string{"istio mode not set for endpoint with address def.foo.com."},
+		},
+		{
+			"AllEndpointsWithLocalityWithIstioModeLabel",
+			&v1alpha3.ServiceEntry{
+				Spec: istioNetworkingV1Alpha3.ServiceEntry{
+					Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
+						{Address: "abc.foo.com.", Locality: "us-west-2", Labels: map[string]string{"type": common.Rollout, "security.istio.io/tlsMode": "istio"}},
+						{Address: "def.foo.com.", Locality: "us-east-2", Labels: map[string]string{"type": common.Rollout, "security.istio.io/tlsMode": "istio"}},
+					},
+				},
+			},
+			true,
+			nil,
 		},
 	}
 
 	for _, tt := range testCases {
-		result := validateLocalityInServiceEntry(tt.entry)
+		result, err := validateServiceEntry(tt.entry)
 		if result != tt.expected {
 			t.Errorf("Test failed: %s \nExpected: %v \nGot: %v", tt.name, tt.expected, result)
+		}
+		if tt.expectedErr == nil {
+			assert.Nil(t, err)
+		} else {
+			for i, expectedErr := range tt.expectedErr.([]string) {
+				assert.Contains(t, err.Error(), expectedErr, "Error %d: %s", i, expectedErr)
+			}
 		}
 	}
 }

--- a/admiral/pkg/clusters/serviceentry_test.go
+++ b/admiral/pkg/clusters/serviceentry_test.go
@@ -10188,7 +10188,7 @@ func TestValidateLocalityInServiceEntry(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		result, err := validateServiceEntry(tt.entry)
+		result, err := validateServiceEntryEndpoints(tt.entry)
 		if result != tt.expected {
 			t.Errorf("Test failed: %s \nExpected: %v \nGot: %v", tt.name, tt.expected, result)
 		}

--- a/admiral/pkg/clusters/shard_handler_test.go
+++ b/admiral/pkg/clusters/shard_handler_test.go
@@ -159,7 +159,7 @@ func TestShardHandler_Added(t *testing.T) {
 		Endpoints: []*istioNetworkingV1Alpha3.WorkloadEntry{
 			{Address: "abc-elb.us-east-2.elb.amazonaws.com.",
 				Ports:    map[string]uint32{"http": 15443},
-				Labels:   map[string]string{"security.istio.io/tlsMode": "istio", "type": "deployment"},
+				Labels:   map[string]string{"security.istio.io/tlsMode": "istio"},
 				Locality: "us-east-2"},
 		},
 		ExportTo:        []string{common.NamespaceIstioSystem, "services-inboundd268-usw2-dev"},

--- a/admiral/pkg/clusters/util_test.go
+++ b/admiral/pkg/clusters/util_test.go
@@ -907,6 +907,7 @@ func generateSEGivenIdentity(deployment1Identity string) *istioNetworkingV1Alpha
 					"http": 0,
 				},
 				Locality: "us-west-2",
+				Labels:   map[string]string{"security.istio.io/tlsMode": "istio"},
 			},
 		},
 		SubjectAltNames: []string{"spiffe://prefix/" + deployment1Identity},

--- a/admiral/pkg/controller/util/migration.go
+++ b/admiral/pkg/controller/util/migration.go
@@ -34,7 +34,7 @@ func UpdateEndpointsForDeployToRolloutMigration(serviceInstance map[string]*k8sV
 					Address:  deployLocalFqdn,
 					Locality: ep.Locality,
 					Ports:    meshPorts[common.Deployment],
-					Labels:   map[string]string{"type": common.Deployment},
+					Labels:   map[string]string{"type": common.Deployment, "security.istio.io/tlsMode": "istio"},
 				}
 				uniqueEndpointsList = append(uniqueEndpointsList, deployEp)
 				requiredServices = append(requiredServices, serviceInstance[common.Deployment])
@@ -45,7 +45,7 @@ func UpdateEndpointsForDeployToRolloutMigration(serviceInstance map[string]*k8sV
 					Address:  rolloutFqdn,
 					Locality: ep.Locality,
 					Ports:    meshPorts[common.Rollout],
-					Labels:   map[string]string{"type": common.Rollout},
+					Labels:   map[string]string{"type": common.Rollout, "security.istio.io/tlsMode": "istio"},
 				}
 				uniqueEndpointsList = append(uniqueEndpointsList, rolloutEp)
 				requiredServices = append(requiredServices, serviceInstance[common.Rollout])
@@ -53,7 +53,7 @@ func UpdateEndpointsForDeployToRolloutMigration(serviceInstance map[string]*k8sV
 		} else {
 			// TODO: check when will this be applicable, and then
 			// update the required service accordingly
-			ep.Labels = nil
+			delete(ep.Labels, "type")
 			uniqueEndpointsList = append(uniqueEndpointsList, ep)
 		}
 	}

--- a/admiral/pkg/controller/util/migration_test.go
+++ b/admiral/pkg/controller/util/migration_test.go
@@ -35,7 +35,7 @@ func TestUpdateEndpointsForDeployToRolloutMigration(t *testing.T) {
 		Resolution:      networking.ServiceEntry_DNS,
 		SubjectAltNames: []string{"spiffe://prefix/my-first-service"},
 		Endpoints: []*networking.WorkloadEntry{
-			{Address: "dummy.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2", Labels: map[string]string{"type": common.Deployment}},
+			{Address: "dummy.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2", Labels: map[string]string{"type": common.Deployment, "security.istio.io/tlsMode": "istio"}},
 		},
 	}
 
@@ -48,7 +48,7 @@ func TestUpdateEndpointsForDeployToRolloutMigration(t *testing.T) {
 		Resolution:      networking.ServiceEntry_DNS,
 		SubjectAltNames: []string{"spiffe://prefix/my-first-service"},
 		Endpoints: []*networking.WorkloadEntry{
-			{Address: "dummy.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2", Labels: map[string]string{"type": common.Rollout}},
+			{Address: "dummy.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2", Labels: map[string]string{"type": common.Rollout, "security.istio.io/tlsMode": "istio"}},
 		},
 	}
 
@@ -61,7 +61,7 @@ func TestUpdateEndpointsForDeployToRolloutMigration(t *testing.T) {
 		Resolution:      networking.ServiceEntry_DNS,
 		SubjectAltNames: []string{"spiffe://prefix/my-first-service"},
 		Endpoints: []*networking.WorkloadEntry{
-			{Address: "dummy.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2", Labels: map[string]string{"type": common.Rollout}},
+			{Address: "dummy.admiral.global", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2", Labels: map[string]string{"type": common.Rollout, "security.istio.io/tlsMode": "istio"}},
 		},
 	}
 
@@ -74,8 +74,8 @@ func TestUpdateEndpointsForDeployToRolloutMigration(t *testing.T) {
 		Resolution:      networking.ServiceEntry_DNS,
 		SubjectAltNames: []string{"spiffe://prefix/my-first-service"},
 		Endpoints: []*networking.WorkloadEntry{
-			{Address: "east.elb.aws.com", Ports: map[string]uint32{"http": 0}, Locality: "us-east-2", Labels: map[string]string{"type": common.Deployment}},
-			{Address: "west.elb.aws.com", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2", Labels: map[string]string{"type": common.Rollout}},
+			{Address: "east.elb.aws.com", Ports: map[string]uint32{"http": 0}, Locality: "us-east-2", Labels: map[string]string{"type": common.Deployment, "security.istio.io/tlsMode": "istio"}},
+			{Address: "west.elb.aws.com", Ports: map[string]uint32{"http": 0}, Locality: "us-west-2", Labels: map[string]string{"type": common.Rollout, "security.istio.io/tlsMode": "istio"}},
 		},
 	}
 
@@ -157,13 +157,13 @@ func TestUpdateEndpointsForDeployToRolloutMigration(t *testing.T) {
 					Address:  "foobar.foobar-ns.svc.cluster.local",
 					Locality: "us-west-2",
 					Ports:    meshPorts[common.Deployment],
-					Labels:   map[string]string{"type": common.Deployment},
+					Labels:   map[string]string{"type": common.Deployment, "security.istio.io/tlsMode": "istio"},
 				},
 				{
 					Address:  "foobar.foobar-ns.svc.cluster.local",
 					Locality: "us-west-2",
 					Ports:    meshPorts[common.Rollout],
-					Labels:   map[string]string{"type": common.Rollout},
+					Labels:   map[string]string{"type": common.Rollout, "security.istio.io/tlsMode": "istio"},
 				},
 			},
 			expectedErr: nil,
@@ -182,18 +182,19 @@ func TestUpdateEndpointsForDeployToRolloutMigration(t *testing.T) {
 					Address:  "foobar.foobar-ns.svc.cluster.local",
 					Locality: "us-east-2",
 					Ports:    meshPorts[common.Deployment],
-					Labels:   map[string]string{"type": common.Deployment},
+					Labels:   map[string]string{"type": common.Deployment, "security.istio.io/tlsMode": "istio"},
 				},
 				{
 					Address:  "foobar.foobar-ns.svc.cluster.local",
 					Locality: "us-east-2",
 					Ports:    meshPorts[common.Rollout],
-					Labels:   map[string]string{"type": common.Rollout},
+					Labels:   map[string]string{"type": common.Rollout, "security.istio.io/tlsMode": "istio"},
 				},
 				{
 					Address:  "west.elb.aws.com",
 					Locality: "us-west-2",
 					Ports:    map[string]uint32{"http": 0},
+					Labels:   map[string]string{"security.istio.io/tlsMode": "istio"},
 				},
 			},
 			expectedErr: nil,
@@ -214,12 +215,13 @@ func TestUpdateEndpointsForDeployToRolloutMigration(t *testing.T) {
 					Address:  "foobar.foobar-ns.svc.cluster.local",
 					Locality: "us-east-2",
 					Ports:    meshPorts[common.Rollout],
-					Labels:   map[string]string{"type": common.Rollout},
+					Labels:   map[string]string{"type": common.Rollout, "security.istio.io/tlsMode": "istio"},
 				},
 				{
 					Address:  "west.elb.aws.com",
 					Locality: "us-west-2",
 					Ports:    map[string]uint32{"http": 0},
+					Labels:   map[string]string{"security.istio.io/tlsMode": "istio"},
 				},
 			},
 			expectedErr: nil,
@@ -240,18 +242,19 @@ func TestUpdateEndpointsForDeployToRolloutMigration(t *testing.T) {
 					Address:  "foobar.foobar-ns.svc.cluster.local",
 					Locality: "us-east-2",
 					Ports:    meshPorts[common.Deployment],
-					Labels:   map[string]string{"type": common.Deployment},
+					Labels:   map[string]string{"type": common.Deployment, "security.istio.io/tlsMode": "istio"},
 				},
 				{
 					Address:  "foobar.foobar-ns.svc.cluster.local",
 					Locality: "us-east-2",
 					Ports:    meshPorts[common.Rollout],
-					Labels:   map[string]string{"type": common.Rollout},
+					Labels:   map[string]string{"type": common.Rollout, "security.istio.io/tlsMode": "istio"},
 				},
 				{
 					Address:  "west.elb.aws.com",
 					Locality: "us-west-2",
 					Ports:    map[string]uint32{"http": 0},
+					Labels:   map[string]string{"security.istio.io/tlsMode": "istio"},
 				},
 			},
 			expectedErr: nil,


### PR DESCRIPTION
- Updated various test cases to include the 'security.istio.io/tlsMode' label in Service Entries and Workload Entries.
- Modified validation logic to check for the presence of the 'security.istio.io/tlsMode' label.
- Refactored code to ensure the 'security.istio.io/tlsMode' label is added where necessary.
- Enhanced error handling in validation functions to provide detailed error messages.

### Checklist
🚨 Please review this repository's [contribution guidelines](./CONTRIBUTING.md).

- [ ] I've read and agree to the project's contribution guidelines.
- [ ] I'm requesting to **pull a topic/feature/bugfix branch**.
- [ ] I checked that my code additions will pass code linting checks and unit tests.
- [ ] I updated unit and integration tests (if applicable).
- [ ] I'm ready to notify the team of this contribution.

### Description
What does this change do and why?

[Link to related ISSUE]

Thank you!