### PR TITLE
creating routing vs in the istio-system ns instead

### DIFF
--- a/admiral/pkg/clusters/serviceentry.go
+++ b/admiral/pkg/clusters/serviceentry.go
@@ -904,8 +904,8 @@ func parseLabels(labels map[string]string) map[string]string {
 	return newLabels
 }
 
-func getExistingVS(ctxLogger *logrus.Entry, ctx context.Context, rc *RemoteController, vsName string) (*v1alpha3.VirtualService, error) {
-	existingVS, err := rc.VirtualServiceController.IstioClient.NetworkingV1alpha3().VirtualServices(common.GetSyncNamespace()).Get(ctx, vsName, v12.GetOptions{})
+func getExistingVS(ctxLogger *logrus.Entry, ctx context.Context, rc *RemoteController, vsName, namespace string) (*v1alpha3.VirtualService, error) {
+	existingVS, err := rc.VirtualServiceController.IstioClient.NetworkingV1alpha3().VirtualServices(namespace).Get(ctx, vsName, v12.GetOptions{})
 	if err != nil && k8sErrors.IsNotFound(err) {
 		ctxLogger.Debugf(LogFormat, "get", common.VirtualServiceResourceType, vsName, rc.ClusterID, "virtualservice not found")
 		return nil, err
@@ -2051,7 +2051,7 @@ func createAdditionalEndpoints(
 
 	defaultVSName := getIstioResourceName(virtualServiceHostnames[0], "-vs")
 
-	existingVS, err := getExistingVS(ctxLogger, ctx, rc, defaultVSName)
+	existingVS, err := getExistingVS(ctxLogger, ctx, rc, defaultVSName, common.GetSyncNamespace())
 	if err != nil {
 		ctxLogger.Warn(err.Error())
 	}

--- a/admiral/pkg/clusters/serviceentry_test.go
+++ b/admiral/pkg/clusters/serviceentry_test.go
@@ -5,10 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/istio-ecosystem/admiral/admiral/pkg/controller/util"
-	"github.com/istio-ecosystem/admiral/admiral/pkg/registry"
-	registryMocks "github.com/istio-ecosystem/admiral/admiral/pkg/registry/mocks"
-	"github.com/stretchr/testify/mock"
 	"os"
 	"reflect"
 	"strconv"
@@ -17,6 +13,11 @@ import (
 	"testing"
 	"time"
 	"unicode"
+
+	"github.com/istio-ecosystem/admiral/admiral/pkg/controller/util"
+	"github.com/istio-ecosystem/admiral/admiral/pkg/registry"
+	registryMocks "github.com/istio-ecosystem/admiral/admiral/pkg/registry/mocks"
+	"github.com/stretchr/testify/mock"
 
 	"k8s.io/client-go/rest"
 
@@ -6535,7 +6536,7 @@ func TestGetExistingVS(t *testing.T) {
 			}
 
 			// Get the existing VirtualService
-			existingVS, err := getExistingVS(ctxLogger, ctx, rc, fakeVS.Name)
+			existingVS, err := getExistingVS(ctxLogger, ctx, rc, fakeVS.Name, common.GetSyncNamespace())
 
 			// Check the results
 			assert.Equal(t, expectedVS, existingVS, "Expected existingVS to match the fakeVS")

--- a/admiral/pkg/clusters/virtualservice_routing.go
+++ b/admiral/pkg/clusters/virtualservice_routing.go
@@ -40,7 +40,7 @@ func getBaseVirtualServiceForIngress() (*v1alpha3.VirtualService, error) {
 
 	return &v1alpha3.VirtualService{
 		ObjectMeta: metaV1.ObjectMeta{
-			Namespace: common.GetSyncNamespace(),
+			Namespace: util.IstioSystemNamespace,
 			Labels:    vsLabels,
 		},
 		Spec: vs,
@@ -547,7 +547,7 @@ func addUpdateVirtualServicesForIngress(
 		}
 		virtualService.Name = vsName
 
-		existingVS, err := getExistingVS(ctxLogger, ctx, rc, virtualService.Name)
+		existingVS, err := getExistingVS(ctxLogger, ctx, rc, virtualService.Name, util.IstioSystemNamespace)
 		if err != nil {
 			ctxLogger.Warn(common.CtxLogFormat, "addUpdateVirtualServicesForIngress",
 				virtualService.Name, virtualService.Namespace, sourceCluster, err.Error())
@@ -556,7 +556,7 @@ func addUpdateVirtualServicesForIngress(
 		ctxLogger.Infof(common.CtxLogFormat, "addUpdateVirtualServicesForIngress",
 			virtualService.Name, virtualService.Namespace, sourceCluster, "Add/Update ingress virtualservice")
 		err = addUpdateVirtualService(
-			ctxLogger, ctx, virtualService, existingVS, common.GetSyncNamespace(), rc, remoteRegistry)
+			ctxLogger, ctx, virtualService, existingVS, util.IstioSystemNamespace, rc, remoteRegistry)
 		if err != nil {
 			ctxLogger.Errorf(common.CtxLogFormat, "addUpdateVirtualServicesForIngress",
 				virtualService.Name, virtualService.Namespace, sourceCluster, err.Error())

--- a/admiral/pkg/clusters/virtualservice_routing_test.go
+++ b/admiral/pkg/clusters/virtualservice_routing_test.go
@@ -32,7 +32,7 @@ func TestAddUpdateVirtualServicesForIngress(t *testing.T) {
 	existingVS := &apiNetworkingV1Alpha3.VirtualService{
 		ObjectMeta: metaV1.ObjectMeta{
 			Name:      "test-env.test-identity.global-routing-vs",
-			Namespace: "test-sync-ns",
+			Namespace: util.IstioSystemNamespace,
 			Labels:    vsLabels,
 		},
 		Spec: networkingV1Alpha3.VirtualService{
@@ -64,7 +64,6 @@ func TestAddUpdateVirtualServicesForIngress(t *testing.T) {
 
 	admiralParams := common.AdmiralParams{
 		LabelSet:                    &common.LabelSet{},
-		SyncNamespace:               "test-sync-ns",
 		EnableSWAwareNSCaches:       true,
 		IngressVSExportToNamespaces: []string{"istio-system"},
 		VSRoutingGateways:           []string{"istio-system/passthrough-gateway"},
@@ -75,7 +74,7 @@ func TestAddUpdateVirtualServicesForIngress(t *testing.T) {
 	common.InitializeConfig(admiralParams)
 
 	istioClientWithExistingVS := istioFake.NewSimpleClientset()
-	istioClientWithExistingVS.NetworkingV1alpha3().VirtualServices(admiralParams.SyncNamespace).
+	istioClientWithExistingVS.NetworkingV1alpha3().VirtualServices(util.IstioSystemNamespace).
 		Create(context.Background(), existingVS, metaV1.CreateOptions{})
 
 	istioClientWithNoExistingVS := istioFake.NewSimpleClientset()
@@ -195,7 +194,7 @@ func TestAddUpdateVirtualServicesForIngress(t *testing.T) {
 			expectedVS: &apiNetworkingV1Alpha3.VirtualService{
 				ObjectMeta: metaV1.ObjectMeta{
 					Name:      "test-env.test-identity.global-routing-vs",
-					Namespace: "test-sync-ns",
+					Namespace: util.IstioSystemNamespace,
 					Labels:    vsLabels,
 				},
 				Spec: networkingV1Alpha3.VirtualService{
@@ -237,7 +236,7 @@ func TestAddUpdateVirtualServicesForIngress(t *testing.T) {
 			expectedVS: &apiNetworkingV1Alpha3.VirtualService{
 				ObjectMeta: metaV1.ObjectMeta{
 					Name:      "test-env.test-identity.global-routing-vs",
-					Namespace: "test-sync-ns",
+					Namespace: util.IstioSystemNamespace,
 					Labels:    vsLabels,
 				},
 				Spec: networkingV1Alpha3.VirtualService{
@@ -279,7 +278,7 @@ func TestAddUpdateVirtualServicesForIngress(t *testing.T) {
 			expectedVS: &apiNetworkingV1Alpha3.VirtualService{
 				ObjectMeta: metaV1.ObjectMeta{
 					Name:      "test-env.test-identity.global-routing-vs",
-					Namespace: "test-sync-ns",
+					Namespace: util.IstioSystemNamespace,
 					Labels:    vsLabels,
 				},
 				Spec: networkingV1Alpha3.VirtualService{
@@ -465,7 +464,7 @@ func TestAddUpdateVirtualServicesForIngress(t *testing.T) {
 				require.Nil(t, err)
 				actualVS, err := tc.istioClient.
 					NetworkingV1alpha3().
-					VirtualServices("test-sync-ns").
+					VirtualServices(util.IstioSystemNamespace).
 					Get(context.Background(), "test-env.test-identity.global-routing-vs", metaV1.GetOptions{})
 				require.Nil(t, err)
 				require.Equal(t, tc.expectedVS.Spec.Tls, actualVS.Spec.Tls)
@@ -1319,7 +1318,6 @@ func TestPopulateDestinationsForCanaryStrategy(t *testing.T) {
 func TestGetBaseVirtualServiceForIngress(t *testing.T) {
 
 	admiralParams := common.AdmiralParams{
-		SyncNamespace:               "test-sync-ns",
 		IngressVSExportToNamespaces: []string{"istio-system"},
 	}
 
@@ -1329,7 +1327,7 @@ func TestGetBaseVirtualServiceForIngress(t *testing.T) {
 
 	validVS := &apiNetworkingV1Alpha3.VirtualService{
 		ObjectMeta: metaV1.ObjectMeta{
-			Namespace: "test-sync-ns",
+			Namespace: util.IstioSystemNamespace,
 			Labels:    vsLabels,
 		},
 		Spec: networkingV1Alpha3.VirtualService{

--- a/install/admiralremote/base/remote.yaml
+++ b/install/admiralremote/base/remote.yaml
@@ -172,3 +172,33 @@ metadata:
   annotations:
     kubernetes.io/service-account.name: admiral
 type: kubernetes.io/service-account-token
+
+---
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: admiral-sync-write-vs-dr
+  namespace: istio-system
+rules:
+  - apiGroups: ["networking.istio.io"]
+    resources: ['virtualservices', 'destinationrules']
+    verbs: ["create", "update", "delete"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: admiral-sync-write-vs-dr-binding
+  namespace: istio-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: admiral-sync-write-vs-dr
+subjects:
+  - kind: ServiceAccount
+    name: admiral
+    namespace: admiral-sync
+
+---


### PR DESCRIPTION
Looks like there is a bug while trying to create VS with SNI host in any other NS apart from `istio-system` NS.
To circumvent that, I changed to create the routing VS in the istio-system NS for now. Will create an issue with istio community.