### PR TITLE
MESH-000-Solve Split Brain (#823)

### DIFF
--- a/admiral/cmd/admiral/cmd/root.go
+++ b/admiral/cmd/admiral/cmd/root.go
@@ -241,6 +241,7 @@ func GetRootCmd(args []string) *cobra.Command {
 	rootCmd.PersistentFlags().Int64Var(&params.DefaultWarmupDurationSecs, "default_warmup_duration_in_seconds", 45, "The default value for the warmupDurationSecs to be used on Destination Rules created by admiral")
 
 	rootCmd.PersistentFlags().BoolVar(&params.EnableGenerationCheck, "enable_generation_check", true, "Enable/Disable Generation Check")
+	rootCmd.PersistentFlags().BoolVar(&params.PreventSplitBrain, "prevent_split_brain", true, "Enable/Disable Explicit Split Brain prevention logic")
 
 	//Admiral 2.0 flags
 	rootCmd.PersistentFlags().BoolVar(&params.AdmiralOperatorMode, "admiral_operator_mode", false, "Enable/Disable admiral operator functionality")

--- a/admiral/pkg/clusters/serviceentry_test.go
+++ b/admiral/pkg/clusters/serviceentry_test.go
@@ -77,6 +77,7 @@ func admiralParamsForServiceEntryTests() common.AdmiralParams {
 		WorkloadSidecarName:               "default",
 		Profile:                           common.AdmiralProfileDefault,
 		DependentClusterWorkerConcurrency: 5,
+		PreventSplitBrain:                 true,
 	}
 }
 
@@ -4184,7 +4185,7 @@ func TestHandleDynamoDbUpdateForOldGtp(t *testing.T) {
 	}
 }
 
-func TestUpdateGlobalGtpCache(t *testing.T) {
+func TestupdateGlobalGtpCacheAndGetGtpPreferenceRegion(t *testing.T) {
 	setupForServiceEntryTests()
 	var (
 		remoteRegistryWithoutGtpWithoutAdmiralClient = &RemoteRegistry{
@@ -4339,7 +4340,7 @@ func TestUpdateGlobalGtpCache(t *testing.T) {
 
 	for _, c := range testCases {
 		t.Run(c.name, func(t *testing.T) {
-			err := updateGlobalGtpCache(c.remoteRegistry, c.identity, c.env, c.gtps, "", ctxLogger)
+			_, err := updateGlobalGtpCacheAndGetGtpPreferenceRegion(c.remoteRegistry, c.identity, c.env, c.gtps, "", ctxLogger)
 			if c.expectedErr == nil {
 				if err != nil {
 					t.Errorf("expected error to be: nil, got: %v", err)
@@ -10200,5 +10201,92 @@ func TestValidateLocalityInServiceEntry(t *testing.T) {
 				assert.Contains(t, err.Error(), expectedErr, "Error %d: %s", i, expectedErr)
 			}
 		}
+	}
+}
+
+func TestOrderSourceClusters(t *testing.T) {
+	rc1 := &RemoteController{
+		NodeController: &admiral.NodeController{
+			Locality: &admiral.Locality{
+				Region: "us-east-2",
+			},
+		},
+	}
+	rc2 := &RemoteController{
+		NodeController: &admiral.NodeController{
+			Locality: &admiral.Locality{
+				Region: "us-west-2",
+			},
+		},
+	}
+	rc3 := &RemoteController{
+		NodeController: &admiral.NodeController{
+			Locality: &admiral.Locality{
+				Region: "us-apse-2",
+			},
+		},
+	}
+
+	tests := []struct {
+		desc       string
+		gtpPrefReg string
+		rcMap      map[string]*RemoteController
+		services   map[string]map[string]*v1.Service
+		enabled    bool
+		expected   string
+	}{
+		{
+			desc:       "Empty services",
+			gtpPrefReg: "",
+			rcMap:      map[string]*RemoteController{},
+			services:   map[string]map[string]*v1.Service{},
+			expected:   "",
+		},
+		{
+			desc:       "Cluster in gtp preference region",
+			gtpPrefReg: "us-west-2",
+			rcMap:      map[string]*RemoteController{"cluster2": rc2, "cluster1": rc1, "cluster3": rc3},
+			services:   map[string]map[string]*v1.Service{"cluster1": {}, "cluster2": {}, "cluster3": {}},
+			enabled:    true,
+			expected:   "cluster2",
+		},
+	}
+
+	for _, tC := range tests {
+		t.Run(tC.desc, func(t *testing.T) {
+			common.ResetSync()
+			rr, _ := InitAdmiral(context.Background(), common.AdmiralParams{
+				KubeconfigPath: "testdata/fake.config",
+				LabelSet: &common.LabelSet{
+					GatewayApp:              "gatewayapp",
+					WorkloadIdentityKey:     "identity",
+					PriorityKey:             "priority",
+					EnvKey:                  "env",
+					AdmiralCRDIdentityLabel: "identity",
+				},
+				EnableSAN:                         true,
+				SANPrefix:                         "prefix",
+				HostnameSuffix:                    "mesh",
+				SyncNamespace:                     "ns",
+				CacheReconcileDuration:            0,
+				ClusterRegistriesNamespace:        "default",
+				DependenciesNamespace:             "default",
+				WorkloadSidecarName:               "default",
+				Profile:                           common.AdmiralProfileDefault,
+				DependentClusterWorkerConcurrency: 5,
+				PreventSplitBrain:                 tC.enabled,
+			})
+			for c, rc := range tC.rcMap {
+				rr.PutRemoteController(c, rc)
+			}
+			ctx := context.WithValue(context.Background(), common.GtpPreferenceRegion, tC.gtpPrefReg)
+			result := orderSourceClusters(ctx, rr, tC.services)
+
+			if tC.expected == "" {
+				assert.Equal(t, 0, len(result))
+			} else if !reflect.DeepEqual(result[0], tC.expected) {
+				t.Fatalf("Expected %v, but got %v", tC.expected, result)
+			}
+		})
 	}
 }

--- a/admiral/pkg/controller/common/common_test.go
+++ b/admiral/pkg/controller/common/common_test.go
@@ -1189,38 +1189,38 @@ func TestShouldIgnore(t *testing.T) {
 	initConfig(true, true)
 
 	testCases := []struct {
-		name     		string
-		annotations   	map[string]string
-		labels   		map[string]string
-		expected 		bool
+		name        string
+		annotations map[string]string
+		labels      map[string]string
+		expected    bool
 	}{
 		{
 			name: "Given valid admiral ignore label " +
 				"Should ignore the object ",
-			annotations:  map[string]string{"sidecar.istio.io/inject": "true"},
-			labels:   map[string]string{"admiral.io/ignore": "true", "app": "app"},
-			expected: true,
+			annotations: map[string]string{"sidecar.istio.io/inject": "true"},
+			labels:      map[string]string{"admiral.io/ignore": "true", "app": "app"},
+			expected:    true,
 		},
 		{
 			name: "Given istio injection is not enabled " +
 				"Should ignore the object ",
-			annotations:  map[string]string{},
-			labels:   map[string]string{"app": "app"},
-			expected: true,
+			annotations: map[string]string{},
+			labels:      map[string]string{"app": "app"},
+			expected:    true,
 		},
 		{
 			name: "Given valid admiral ignore annotation " +
 				"Should ignore the object ",
-			annotations:  map[string]string{"admiral.io/ignore": "true", "sidecar.istio.io/inject": "true"},
-			labels:   map[string]string{"app": "app"},
-			expected: true,
+			annotations: map[string]string{"admiral.io/ignore": "true", "sidecar.istio.io/inject": "true"},
+			labels:      map[string]string{"app": "app"},
+			expected:    true,
 		},
 		{
 			name: "Given no admiral ignore set " +
 				"Should not ignore the object ",
-			annotations:   map[string]string{"sidecar.istio.io/inject": "true"},
-			labels:   map[string]string{"app": "app"},
-			expected: false,
+			annotations: map[string]string{"sidecar.istio.io/inject": "true"},
+			labels:      map[string]string{"app": "app"},
+			expected:    false,
 		},
 	}
 
@@ -1238,31 +1238,31 @@ func TestGetIdentityPartition(t *testing.T) {
 	initConfig(true, true)
 
 	testCases := []struct {
-		name     		string
-		annotations   	map[string]string
-		labels   		map[string]string
-		expected 		string
+		name        string
+		annotations map[string]string
+		labels      map[string]string
+		expected    string
 	}{
 		{
 			name: "Given valid identity partition on annotations " +
 				"Should return identity partition ",
-			annotations:  map[string]string{"admiral.io/identityPartition": "partition1"},
-			labels:   map[string]string{"app": "app"},
-			expected: "partition1",
+			annotations: map[string]string{"admiral.io/identityPartition": "partition1"},
+			labels:      map[string]string{"app": "app"},
+			expected:    "partition1",
 		},
 		{
 			name: "Given valid identity partition on labels " +
 				"Should return identity partition ",
-			annotations:  map[string]string{},
-			labels:   map[string]string{"app": "app", "admiral.io/identityPartition": "partition2"},
-			expected: "partition2",
+			annotations: map[string]string{},
+			labels:      map[string]string{"app": "app", "admiral.io/identityPartition": "partition2"},
+			expected:    "partition2",
 		},
 		{
 			name: "Given no valid identity partition present on labels or annotations " +
 				"Should return empty string ",
-			annotations:  map[string]string{},
-			labels:   map[string]string{"app": "app"},
-			expected: "",
+			annotations: map[string]string{},
+			labels:      map[string]string{"app": "app"},
+			expected:    "",
 		},
 	}
 
@@ -1280,38 +1280,38 @@ func TestGetGlobalIdentifier(t *testing.T) {
 	initConfig(true, true)
 
 	testCases := []struct {
-		name     		string
-		annotations   	map[string]string
-		labels   		map[string]string
-		expected 		string
+		name        string
+		annotations map[string]string
+		labels      map[string]string
+		expected    string
 	}{
 		{
 			name: "Given valid identity partition on annotations and valid identity" +
 				"Should return global identifier with identity partition ",
-			annotations:  map[string]string{"admiral.io/identityPartition": "partition1"},
-			labels:   map[string]string{"app": "app", "identity": "identity1"},
-			expected: "partition1.identity1",
+			annotations: map[string]string{"admiral.io/identityPartition": "partition1"},
+			labels:      map[string]string{"app": "app", "identity": "identity1"},
+			expected:    "partition1.identity1",
 		},
 		{
 			name: "Given valid identity partition on labels and valid identity " +
 				"Should return global identifier with identity partition ",
-			annotations:  map[string]string{},
-			labels:   map[string]string{"app": "app", "admiral.io/identityPartition": "partition2", "identity": "identity2"},
-			expected: "partition2.identity2",
+			annotations: map[string]string{},
+			labels:      map[string]string{"app": "app", "admiral.io/identityPartition": "partition2", "identity": "identity2"},
+			expected:    "partition2.identity2",
 		},
 		{
 			name: "Given no valid identity partition present on labels or annotations and valid identity " +
 				"Should return identity string ",
-			annotations:  map[string]string{},
-			labels:   map[string]string{"app": "app", "identity": "identity3"},
-			expected: "identity3",
+			annotations: map[string]string{},
+			labels:      map[string]string{"app": "app", "identity": "identity3"},
+			expected:    "identity3",
 		},
 		{
 			name: "Given no valid identity partition and no valid identity " +
 				"Should empty string ",
-			annotations:  map[string]string{},
-			labels:   map[string]string{"app": "app"},
-			expected: "",
+			annotations: map[string]string{},
+			labels:      map[string]string{"app": "app"},
+			expected:    "",
 		},
 	}
 
@@ -1329,31 +1329,31 @@ func TestGetOriginalIdentifier(t *testing.T) {
 	initConfig(true, true)
 
 	testCases := []struct {
-		name     		string
-		annotations   	map[string]string
-		labels   		map[string]string
-		expected 		string
+		name        string
+		annotations map[string]string
+		labels      map[string]string
+		expected    string
 	}{
 		{
 			name: "Given valid identity on annotations " +
 				"Should return identity ",
-			annotations:  map[string]string{"identity": "identity1"},
-			labels:   map[string]string{"app": "app"},
-			expected: "identity1",
+			annotations: map[string]string{"identity": "identity1"},
+			labels:      map[string]string{"app": "app"},
+			expected:    "identity1",
 		},
 		{
 			name: "Given valid identity on labels " +
 				"Should return identity ",
-			annotations:  map[string]string{},
-			labels:   map[string]string{"app": "app", "identity": "identity2"},
-			expected: "identity2",
+			annotations: map[string]string{},
+			labels:      map[string]string{"app": "app", "identity": "identity2"},
+			expected:    "identity2",
 		},
 		{
 			name: "Given no valid identity on labels or annotations " +
 				"Should return empty identity ",
-			annotations:  map[string]string{},
-			labels:   map[string]string{"app": "app"},
-			expected: "",
+			annotations: map[string]string{},
+			labels:      map[string]string{"app": "app"},
+			expected:    "",
 		},
 	}
 
@@ -1497,6 +1497,235 @@ func TestGetPartitionAndOriginalIdentifierFromPartitionedIdentifier(t *testing.T
 			partition, originalIdentifier := GetPartitionAndOriginalIdentifierFromPartitionedIdentifier(c.identifier)
 			if !(partition == c.expectedPartition && originalIdentifier == c.expectedOriginalIdentifier) {
 				t.Errorf("Wanted partition: %s, original identifier: %s, got: %s, %s", c.expectedPartition, c.expectedOriginalIdentifier, partition, originalIdentifier)
+			}
+		})
+	}
+}
+
+func TestGetGtpPreferenceRegion(t *testing.T) {
+	testCases := []struct {
+		name           string
+		existingGtp    *admiralV1Alpha1.GlobalTrafficPolicy
+		newGtp         *admiralV1Alpha1.GlobalTrafficPolicy
+		expectedRegion string
+	}{
+		{
+			name: "Returns current region for same GTP",
+			existingGtp: &admiralV1Alpha1.GlobalTrafficPolicy{
+				Spec: model.GlobalTrafficPolicy{
+					Policy: []*model.TrafficPolicy{
+						{
+							LbType:    1,
+							DnsPrefix: "west",
+							Target: []*model.TrafficGroup{
+								{
+									Region: "us-west-2",
+									Weight: 100,
+								},
+							},
+						},
+					},
+				},
+			},
+			newGtp: &admiralV1Alpha1.GlobalTrafficPolicy{
+				Spec: model.GlobalTrafficPolicy{
+					Policy: []*model.TrafficPolicy{
+						{
+							LbType:    1,
+							DnsPrefix: "west",
+							Target: []*model.TrafficGroup{
+								{
+									Region: "us-west-2",
+									Weight: 100,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedRegion: "",
+		},
+		{
+			name: "Returns error for different prefix count",
+			existingGtp: &admiralV1Alpha1.GlobalTrafficPolicy{
+				Spec: model.GlobalTrafficPolicy{
+					Policy: []*model.TrafficPolicy{
+						{
+							LbType:    1,
+							DnsPrefix: "west",
+							Target: []*model.TrafficGroup{
+								{
+									Region: "us-west-2",
+									Weight: 100,
+								},
+							},
+						},
+					},
+				},
+			},
+			newGtp: &admiralV1Alpha1.GlobalTrafficPolicy{
+				Spec: model.GlobalTrafficPolicy{
+					Policy: []*model.TrafficPolicy{
+						{
+							LbType:    1,
+							DnsPrefix: "west",
+							Target: []*model.TrafficGroup{
+								{
+									Region: "us-east-2",
+									Weight: 100,
+								},
+							},
+						},
+						{
+							LbType:    1,
+							DnsPrefix: "east",
+							Target: []*model.TrafficGroup{
+								{
+									Region: "us-west-2",
+									Weight: 100,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedRegion: "us-east-2",
+		},
+		{
+			name: "Returns no region for different weight",
+			existingGtp: &admiralV1Alpha1.GlobalTrafficPolicy{
+				Spec: model.GlobalTrafficPolicy{
+					Policy: []*model.TrafficPolicy{
+						{
+							LbType:    1,
+							DnsPrefix: "west",
+							Target: []*model.TrafficGroup{
+								{
+									Region: "us-west-2",
+									Weight: 100,
+								},
+							},
+						},
+					},
+				},
+			},
+			newGtp: &admiralV1Alpha1.GlobalTrafficPolicy{
+				Spec: model.GlobalTrafficPolicy{
+					Policy: []*model.TrafficPolicy{
+						{
+							LbType:    1,
+							DnsPrefix: "west",
+							Target: []*model.TrafficGroup{
+								{
+									Region: "us-west-2",
+									Weight: 80,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedRegion: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			region := GetGtpPreferenceRegion(tc.existingGtp, tc.newGtp)
+
+			if region != tc.expectedRegion {
+				t.Errorf("got region %s; want %s", region, tc.expectedRegion)
+			}
+		})
+	}
+}
+
+func TestMakeDnsPrefixRegionMapping(t *testing.T) {
+	testCases := []struct {
+		name     string
+		gtp      *admiralV1Alpha1.GlobalTrafficPolicy
+		expected map[string]string
+	}{
+		{
+			name: "valid mapping with 100 weight",
+			gtp: &admiralV1Alpha1.GlobalTrafficPolicy{
+				Spec: model.GlobalTrafficPolicy{
+					Policy: []*model.TrafficPolicy{
+						{
+							LbType:    model.TrafficPolicy_FAILOVER,
+							DnsPrefix: "test-prefix",
+							Target: []*model.TrafficGroup{
+								{
+									Region: "us-west-2",
+									Weight: int32(100),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]string{"test-prefix": "us-west-2"},
+		},
+		{
+			name: "no mapping with weight less than 100",
+			gtp: &admiralV1Alpha1.GlobalTrafficPolicy{
+				Spec: model.GlobalTrafficPolicy{
+					Policy: []*model.TrafficPolicy{
+						{
+							LbType:    model.TrafficPolicy_FAILOVER,
+							DnsPrefix: "test-prefix",
+							Target: []*model.TrafficGroup{
+								{
+									Region: "us-west-2",
+									Weight: int32(50),
+								},
+								{
+									Region: "us-east-2",
+									Weight: int32(50),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{
+			name: "empty policy",
+			gtp: &admiralV1Alpha1.GlobalTrafficPolicy{
+				Spec: model.GlobalTrafficPolicy{
+					Policy: []*model.TrafficPolicy{},
+				},
+			},
+			expected: map[string]string{},
+		},
+		{
+			name: "non-failover lb type",
+			gtp: &admiralV1Alpha1.GlobalTrafficPolicy{
+				Spec: model.GlobalTrafficPolicy{
+					Policy: []*model.TrafficPolicy{
+						{
+							LbType:    model.TrafficPolicy_TOPOLOGY, // not FAILOVER
+							DnsPrefix: "test-prefix",
+							Target: []*model.TrafficGroup{
+								{
+									Region: "us-east-2",
+									Weight: int32(100),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]string{},
+		},
+	}
+
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+			result := makeDnsPrefixRegionMapping(c.gtp)
+			if !reflect.DeepEqual(result, c.expected) {
+				t.Errorf("Wanted DNS region mapping: %v, got: %v", c.expected, result)
 			}
 		})
 	}

--- a/admiral/pkg/controller/common/config.go
+++ b/admiral/pkg/controller/common/config.go
@@ -467,6 +467,12 @@ func DoGenerationCheck() bool {
 	return wrapper.params.EnableGenerationCheck
 }
 
+func PreventSplitBrain() bool {
+	wrapper.RLock()
+	defer wrapper.RUnlock()
+	return wrapper.params.PreventSplitBrain
+}
+
 func GetResyncIntervals() util.ResyncIntervals {
 	wrapper.RLock()
 	defer wrapper.RUnlock()

--- a/admiral/pkg/controller/common/types.go
+++ b/admiral/pkg/controller/common/types.go
@@ -99,6 +99,7 @@ type AdmiralParams struct {
 	EnableSyncIstioResourcesToSourceClusters bool
 	DefaultWarmupDurationSecs                int64
 	EnableGenerationCheck                    bool
+	PreventSplitBrain                        bool
 
 	// Cartographer specific params
 	TrafficConfigPersona      bool
@@ -128,9 +129,9 @@ type AdmiralParams struct {
 	VSRoutingEnabledClusters    []string
 
 	//Client discovery (types requiring mesh egress only)
-	EnableClientDiscovery		bool
+	EnableClientDiscovery          bool
 	ClientDiscoveryClustersForJobs []string
-	DiscoveryClustersForNumaflow []string
+	DiscoveryClustersForNumaflow   []string
 }
 
 func (b AdmiralParams) String() string {
@@ -465,10 +466,10 @@ func (s *ProxiedServiceEnvironment) String() string {
 }
 
 type K8sObject struct {
-	Name string
-	Namespace string
-	Type string
+	Name        string
+	Namespace   string
+	Type        string
 	Annotations map[string]string
-	Labels map[string]string
-	Status string
+	Labels      map[string]string
+	Status      string
 }


### PR DESCRIPTION
* MESH-000: Implement split-brain prevention logic

- Added `PreventSplitBrain` flag to enable/disable explicit split-brain prevention logic.
- Introduced `orderSourceClusters` function to prioritize clusters based on GTP preference region.
- Updated `updateGlobalGtpCache` to utilize context for GTP preference region handling.
- Added utility functions `GetGtpPreferenceRegion` and `makeDnsPrefixRegionMapping` for GTP region mapping.
- Updated tests to include split-brain prevention scenarios.

### Checklist
🚨 Please review this repository's [contribution guidelines](./CONTRIBUTING.md).

- [ ] I've read and agree to the project's contribution guidelines.
- [ ] I'm requesting to **pull a topic/feature/bugfix branch**.
- [ ] I checked that my code additions will pass code linting checks and unit tests.
- [ ] I updated unit and integration tests (if applicable).
- [ ] I'm ready to notify the team of this contribution.

### Description
What does this change do and why?

[Link to related ISSUE]

Thank you!