### PR TITLE
MESH-000: Implement client-initiated processing feature (#815)

### DIFF
--- a/admiral/cmd/admiral/cmd/root.go
+++ b/admiral/cmd/admiral/cmd/root.go
@@ -241,6 +241,7 @@ func GetRootCmd(args []string) *cobra.Command {
 	rootCmd.PersistentFlags().Int64Var(&params.DefaultWarmupDurationSecs, "default_warmup_duration_in_seconds", 45, "The default value for the warmupDurationSecs to be used on Destination Rules created by admiral")
 
 	rootCmd.PersistentFlags().BoolVar(&params.EnableGenerationCheck, "enable_generation_check", true, "Enable/Disable Generation Check")
+	rootCmd.PersistentFlags().BoolVar(&params.ClientInitiatedProcessingEnabled, "client_initiated_processing_enabled", true, "Enable/Disable Client Initiated Processing")
 	rootCmd.PersistentFlags().BoolVar(&params.PreventSplitBrain, "prevent_split_brain", true, "Enable/Disable Explicit Split Brain prevention logic")
 
 	//Admiral 2.0 flags

--- a/admiral/pkg/clusters/dependency_handler.go
+++ b/admiral/pkg/clusters/dependency_handler.go
@@ -3,8 +3,6 @@ package clusters
 import (
 	"context"
 	"fmt"
-	"strings"
-
 	v1 "github.com/istio-ecosystem/admiral/admiral/pkg/apis/admiral/v1alpha1"
 	"github.com/istio-ecosystem/admiral/admiral/pkg/controller/admiral"
 	"github.com/istio-ecosystem/admiral/admiral/pkg/controller/common"
@@ -87,30 +85,6 @@ func isIdentityMeshEnabled(identity string, remoteRegistry *RemoteRegistry) bool
 	return false
 }
 
-func getDestinationsToBeProcessed(eventType admiral.EventType,
-	updatedDependency *v1.Dependency, remoteRegistry *RemoteRegistry) ([]string, bool) {
-	updatedDestinations := make([]string, 0)
-	existingDestination := remoteRegistry.AdmiralCache.SourceToDestinations.Get(updatedDependency.Spec.Source)
-	var nonMeshEnabledExists bool
-	lookup := make(map[string]bool)
-	//if this is an update, build a look up table to process only the diff
-	if eventType == admiral.Update {
-		for _, dest := range existingDestination {
-			lookup[dest] = true
-		}
-	}
-
-	for _, destination := range updatedDependency.Spec.Destinations {
-		if !isIdentityMeshEnabled(destination, remoteRegistry) {
-			nonMeshEnabledExists = true
-		}
-		if ok := lookup[destination]; !ok {
-			updatedDestinations = append(updatedDestinations, destination)
-		}
-	}
-	return updatedDestinations, nonMeshEnabledExists
-}
-
 func (d *ProcessDestinationService) Process(ctx context.Context, dependency *v1.Dependency,
 	remoteRegistry *RemoteRegistry, eventType admiral.EventType, modifySE ModifySEFunc) error {
 
@@ -127,10 +101,6 @@ func (d *ProcessDestinationService) Process(ctx context.Context, dependency *v1.
 	destinations, hasNonMeshDestination := getDestinationsToBeProcessed(eventType, dependency, remoteRegistry)
 	log.Infof(LogFormat, string(eventType), common.DependencyResourceType, dependency.Name, "", fmt.Sprintf("found %d new destinations: %v", len(destinations), destinations))
 
-	var processingErrors error
-	var message string
-	counter := 1
-	totalDestinations := len(destinations)
 	// find source cluster for source identity
 	sourceClusters := remoteRegistry.AdmiralCache.IdentityClusterCache.Get(dependency.Spec.Source)
 	if sourceClusters == nil {
@@ -142,96 +112,6 @@ func (d *ProcessDestinationService) Process(ctx context.Context, dependency *v1.
 		return nil
 	}
 
-	for _, destinationIdentity := range destinations {
-		if strings.Contains(strings.ToLower(destinationIdentity), strings.ToLower(common.ServicesGatewayIdentity)) &&
-			!hasNonMeshDestination {
-			log.Infof(LogFormat, string(eventType), common.DependencyResourceType, dependency.Name, "",
-				fmt.Sprintf("All destinations are MESH enabled. Skipping processing: %v. Destinations: %v", destinationIdentity, dependency.Spec.Destinations))
-			continue
-		}
-
-		// In case of self on-boarding skip the update for the destination as it is the same as the source
-		if strings.EqualFold(dependency.Spec.Source, destinationIdentity) {
-			log.Infof(LogFormat, string(eventType), common.DependencyResourceType, dependency.Name, "",
-				fmt.Sprintf("Destination identity is same as source identity. Skipping processing: %v.", destinationIdentity))
-			continue
-		}
-
-		destinationClusters := remoteRegistry.AdmiralCache.IdentityClusterCache.Get(destinationIdentity)
-		log.Infof(LogFormat, string(eventType), common.DependencyResourceType, dependency.Name, "", fmt.Sprintf("processing destination %d/%d destinationIdentity=%s", counter, totalDestinations, destinationIdentity))
-		clusters := remoteRegistry.AdmiralCache.IdentityClusterCache.Get(destinationIdentity)
-		if destinationClusters == nil || destinationClusters.Len() == 0 {
-			listOfSourceClusters := strings.Join(sourceClusters.GetKeys(), ",")
-			log.Infof(LogFormat, string(eventType), common.DependencyResourceType, dependency.Name, listOfSourceClusters,
-				fmt.Sprintf("destinationClusters does not have any clusters. Skipping processing: %v.", destinationIdentity))
-			continue
-		}
-		if clusters == nil {
-			// When destination identity's cluster is not found, then
-			// skip calling modify SE because:
-			// 1. The destination identity might be NON MESH. Which means this error will always happen
-			//    and there is no point calling modifySE.
-			// 2. It could be that the IdentityClusterCache is not updated.
-			//    It is the deployment/rollout controllers responsibility to update the cache
-			//    without which the cache will always be empty. Now when deployment/rollout event occurs
-			//    that will result in calling modify SE and perform the same operations which this function is trying to do
-			log.Infof(LogFormat, string(eventType), common.DependencyResourceType, dependency.Name, "",
-				fmt.Sprintf("no cluster found for destinationIdentity: %s. Skipping calling modifySE", destinationIdentity))
-			continue
-		}
-
-		for _, destinationClusterID := range clusters.GetKeys() {
-			message = fmt.Sprintf("processing cluster=%s for destinationIdentity=%s", destinationClusterID, destinationIdentity)
-			log.Infof(LogFormat, string(eventType), common.DependencyResourceType, dependency.Name, "", message)
-			rc := remoteRegistry.GetRemoteController(destinationClusterID)
-			if rc == nil {
-				processingErrors = common.AppendError(processingErrors,
-					fmt.Errorf("no remote controller found in cache for cluster %s", destinationClusterID))
-				continue
-			}
-			ctx = context.WithValue(ctx, "clusterName", destinationClusterID)
-
-			if rc.DeploymentController != nil {
-				deploymentEnvMap := rc.DeploymentController.Cache.GetByIdentity(destinationIdentity)
-				if len(deploymentEnvMap) != 0 {
-					ctx = context.WithValue(ctx, "eventResourceType", common.Deployment)
-					ctx = context.WithValue(ctx, common.DependentClusterOverride, sourceClusters)
-					for env := range deploymentEnvMap {
-						message = fmt.Sprintf("calling modifySE for env=%s destinationIdentity=%s", env, destinationIdentity)
-						log.Infof(LogFormat, string(eventType), common.DependencyResourceType, dependency.Name, "", message)
-						_, err := modifySE(ctx, eventType, env, destinationIdentity, remoteRegistry)
-						if err != nil {
-							message = fmt.Sprintf("error occurred in modifySE func for env=%s destinationIdentity=%s", env, destinationIdentity)
-							log.Errorf(LogErrFormat, string(eventType), common.DependencyResourceType, dependency.Name, "", err.Error()+". "+message)
-							processingErrors = common.AppendError(processingErrors, err)
-						}
-					}
-					continue
-				}
-			}
-			if rc.RolloutController != nil {
-				rolloutEnvMap := rc.RolloutController.Cache.GetByIdentity(destinationIdentity)
-				if len(rolloutEnvMap) != 0 {
-					ctx = context.WithValue(ctx, "eventResourceType", common.Rollout)
-					ctx = context.WithValue(ctx, common.DependentClusterOverride, sourceClusters)
-					for env := range rolloutEnvMap {
-						message = fmt.Sprintf("calling modifySE for env=%s destinationIdentity=%s", env, destinationIdentity)
-						log.Infof(LogFormat, string(eventType), common.DependencyResourceType, dependency.Name, "", message)
-						_, err := modifySE(ctx, eventType, env, destinationIdentity, remoteRegistry)
-						if err != nil {
-							message = fmt.Sprintf("error occurred in modifySE func for env=%s destinationIdentity=%s", env, destinationIdentity)
-							log.Errorf(LogErrFormat, string(eventType), common.DependencyResourceType, dependency.Name, "", err.Error()+". "+message)
-							processingErrors = common.AppendError(processingErrors, err)
-						}
-					}
-					continue
-				}
-			}
-			log.Infof(LogFormat, string(eventType), common.DependencyResourceType, dependency.Name, "", fmt.Sprintf("done processing destinationIdentity=%s", destinationIdentity))
-			log.Warnf(LogFormat, string(eventType), common.DependencyResourceType, dependency.Name, "",
-				fmt.Sprintf("neither deployment or rollout controller initialized in cluster %s and destination identity %s", destinationClusterID, destinationIdentity))
-			counter++
-		}
-	}
-	return processingErrors
+	err := processDestinationsForSourceIdentity(ctx, remoteRegistry, eventType, hasNonMeshDestination, sourceClusters, destinations, dependency.Name, modifySE)
+	return err
 }

--- a/admiral/pkg/clusters/deployment_handler.go
+++ b/admiral/pkg/clusters/deployment_handler.go
@@ -73,5 +73,11 @@ func HandleEventForDeployment(ctx context.Context, event admiral.EventType, obj 
 
 	// Use the same function as added deployment function to update and put new service entry in place to replace old one
 	_, err := modifyServiceEntryForNewServiceOrPod(ctx, event, env, globalIdentifier, remoteRegistry)
+	if common.ClientInitiatedProcessingEnabled() {
+		depProcessErr := processClientDependencyRecord(ctx, remoteRegistry, globalIdentifier, clusterName, obj.Namespace)
+		if depProcessErr != nil {
+			return common.AppendError(err, depProcessErr)
+		}
+	}
 	return err
 }

--- a/admiral/pkg/clusters/rollout_handler.go
+++ b/admiral/pkg/clusters/rollout_handler.go
@@ -70,5 +70,12 @@ func HandleEventForRollout(ctx context.Context, event admiral.EventType, obj *ar
 
 	// Use the same function as added deployment function to update and put new service entry in place to replace old one
 	_, err := modifyServiceEntryForNewServiceOrPod(ctx, event, env, globalIdentifier, remoteRegistry)
+
+	if common.ClientInitiatedProcessingEnabled() {
+		rolloutProcessErr := processClientDependencyRecord(ctx, remoteRegistry, globalIdentifier, clusterName, obj.Namespace)
+		if rolloutProcessErr != nil {
+			return common.AppendError(err, rolloutProcessErr)
+		}
+	}
 	return err
 }

--- a/admiral/pkg/clusters/serviceentry.go
+++ b/admiral/pkg/clusters/serviceentry.go
@@ -1418,7 +1418,7 @@ func AddServiceEntriesWithDrWorker(
 		start = time.Now()
 		currentDR := getCurrentDRForLocalityLbSetting(rr, isServiceEntryModifyCalledForSourceCluster, cluster, se, partitionedIdentity)
 		ctxLogger.Infof("currentDR set for dr=%v cluster=%v", getIstioResourceName(se.Hosts[0], "-default-dr"), cluster)
-		var seDrSet = createSeAndDrSetFromGtp(ctxLogger, ctx, env, region, cluster, se,
+		var seDrSet, clientNamespaces = createSeAndDrSetFromGtp(ctxLogger, ctx, env, region, cluster, se,
 			globalTrafficPolicy, outlierDetection, clientConnectionSettings, cache, currentDR)
 		util.LogElapsedTimeSinceTask(ctxLogger, "AdmiralCacheCreateSeAndDrSetFromGtp", "", "", cluster, "", start)
 
@@ -1672,6 +1672,10 @@ func AddServiceEntriesWithDrWorker(
 		}
 		if addSEorDRToAClusterError != nil {
 			addSEorDRToAClusterError = common.AppendError(addSEorDRToAClusterError, fmt.Errorf("%s=%s", errorCluster, cluster))
+		} else {
+			for _, clientNs := range clientNamespaces {
+				rr.AdmiralCache.ClientClusterNamespaceServerCache.Put(cluster, clientNs, partitionedIdentity, partitionedIdentity)
+			}
 		}
 		errors <- addSEorDRToAClusterError
 	}
@@ -2183,7 +2187,7 @@ func isGeneratedByCartographer(annotations map[string]string) bool {
 
 func createSeAndDrSetFromGtp(ctxLogger *logrus.Entry, ctx context.Context, env, region string, cluster string,
 	se *networking.ServiceEntry, globalTrafficPolicy *v1.GlobalTrafficPolicy, outlierDetection *v1.OutlierDetection,
-	clientConnectionSettings *v1.ClientConnectionConfig, cache *AdmiralCache, currentDR *v1alpha3.DestinationRule) map[string]*SeDrTuple {
+	clientConnectionSettings *v1.ClientConnectionConfig, cache *AdmiralCache, currentDR *v1alpha3.DestinationRule) (map[string]*SeDrTuple, []string) {
 	var (
 		defaultDrName = getIstioResourceName(se.Hosts[0], "-default-dr")
 		defaultSeName = getIstioResourceName(se.Hosts[0], "-se")
@@ -2194,7 +2198,7 @@ func createSeAndDrSetFromGtp(ctxLogger *logrus.Entry, ctx context.Context, env, 
 	eventResourceType, ok := ctx.Value(common.EventResourceType).(string)
 	if !ok {
 		ctxLogger.Errorf(AlertLogMsg, ctx.Value(common.EventResourceType))
-		return nil
+		return nil, nil
 	}
 
 	event := admiral.Add
@@ -2202,7 +2206,7 @@ func createSeAndDrSetFromGtp(ctxLogger *logrus.Entry, ctx context.Context, env, 
 		event, ok = ctx.Value(common.EventType).(admiral.EventType)
 		if !ok {
 			ctxLogger.Errorf(AlertLogMsg, ctx.Value(common.EventType))
-			return nil
+			return nil, nil
 		}
 	}
 
@@ -2239,7 +2243,7 @@ func createSeAndDrSetFromGtp(ctxLogger *logrus.Entry, ctx context.Context, env, 
 				var newAddress, addressErr = getUniqueAddress(ctxLogger, ctx, cache, host)
 				if addressErr != nil {
 					ctxLogger.Errorf("failed while getting address for %v with error %v", seName, addressErr)
-					return nil
+					return nil, nil
 				}
 				if common.DisableIPGeneration() && len(newAddress) == 0 {
 					modifiedSe.Addresses = []string{}
@@ -2279,7 +2283,7 @@ func createSeAndDrSetFromGtp(ctxLogger *logrus.Entry, ctx context.Context, env, 
 		seDrSet[se.Hosts[0]] = seDr
 	}
 
-	return seDrSet
+	return seDrSet, se.ExportTo
 }
 
 func makeRemoteEndpointForServiceEntry(address string, locality string, portName string, portNumber int, appType string) *networking.WorkloadEntry {

--- a/admiral/pkg/clusters/serviceentry_test.go
+++ b/admiral/pkg/clusters/serviceentry_test.go
@@ -2297,7 +2297,7 @@ func TestCreateSeAndDrSetFromGtp(t *testing.T) {
 			common.ResetSync()
 			common.InitializeConfig(admiralParams)
 			admiralCache.ConfigMapController = c.cc
-			result := createSeAndDrSetFromGtp(ctxLogger, ctx, c.env, c.locality, "fake-cluster", c.se, c.gtp, nil, nil, &admiralCache, nil)
+			result, _ := createSeAndDrSetFromGtp(ctxLogger, ctx, c.env, c.locality, "fake-cluster", c.se, c.gtp, nil, nil, &admiralCache, nil)
 			if c.seDrSet == nil {
 				if !reflect.DeepEqual(result, c.seDrSet) {
 					t.Fatalf("Expected nil seDrSet but got %+v", result)

--- a/admiral/pkg/clusters/types.go
+++ b/admiral/pkg/clusters/types.go
@@ -48,9 +48,9 @@ type RemoteController struct {
 	EnvoyFilterController            *admiral.EnvoyFilterController
 	OutlierDetectionController       *admiral.OutlierDetectionController
 	ClientConnectionConfigController *admiral.ClientConnectionConfigController
-	JobController 					 *admiral.JobController
-	VertexController 				 *admiral.VertexController
-	MonoVertexController			 *admiral.MonoVertexController
+	JobController                    *admiral.JobController
+	VertexController                 *admiral.VertexController
+	MonoVertexController             *admiral.MonoVertexController
 	stop                             chan struct{}
 	//listener for normal types
 }
@@ -80,6 +80,7 @@ type AdmiralCache struct {
 	IdentityClusterNamespaceCache       *common.MapOfMapOfMaps
 	CnameDependentClusterNamespaceCache *common.MapOfMapOfMaps
 	PartitionIdentityCache              *common.Map
+	ClientClusterNamespaceServerCache   *common.MapOfMapOfMaps
 }
 
 type RemoteRegistry struct {
@@ -149,6 +150,7 @@ func NewRemoteRegistry(ctx context.Context, params common.AdmiralParams) *Remote
 		IdentitiesWithAdditionalEndpoints:   &sync.Map{},
 		IdentityClusterNamespaceCache:       common.NewMapOfMapOfMaps(),
 		CnameDependentClusterNamespaceCache: common.NewMapOfMapOfMaps(),
+		ClientClusterNamespaceServerCache:   common.NewMapOfMapOfMaps(),
 		PartitionIdentityCache:              common.NewMap(),
 	}
 	if common.GetAdmiralProfile() == common.AdmiralProfileDefault || common.GetAdmiralProfile() == common.AdmiralProfilePerf {

--- a/admiral/pkg/clusters/util.go
+++ b/admiral/pkg/clusters/util.go
@@ -3,6 +3,8 @@ package clusters
 import (
 	"context"
 	"errors"
+	"fmt"
+	"github.com/prometheus/common/log"
 	"sort"
 	"strings"
 	"time"
@@ -12,6 +14,7 @@ import (
 	commonUtil "github.com/istio-ecosystem/admiral/admiral/pkg/util"
 
 	argo "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	v1 "github.com/istio-ecosystem/admiral/admiral/pkg/apis/admiral/v1alpha1"
 	"github.com/istio-ecosystem/admiral/admiral/pkg/controller/common"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
@@ -342,4 +345,161 @@ func (r RouteDestinationSorted) Less(i, j int) bool {
 
 func (r RouteDestinationSorted) Swap(i, j int) {
 	r[i], r[j] = r[j], r[i]
+}
+
+func processClientDependencyRecord(ctx context.Context, remoteRegistry *RemoteRegistry, globalIdentifier string, clusterName string, clientNs string) error {
+	var destinationsToBeProcessed []string
+
+	destinationsToBeProcessed = getDestinationsToBeProcessedForClientInitiatedProcessing(remoteRegistry, globalIdentifier, clusterName, clientNs, destinationsToBeProcessed)
+
+	var sourceClusterMap = common.NewMap()
+	sourceClusterMap.Put(clusterName, clusterName)
+
+	err := processDestinationsForSourceIdentity(ctx, remoteRegistry, "Update", true, sourceClusterMap, destinationsToBeProcessed, globalIdentifier, modifyServiceEntryForNewServiceOrPod)
+	return err
+}
+
+func getDestinationsToBeProcessedForClientInitiatedProcessing(remoteRegistry *RemoteRegistry, globalIdentifier string, clusterName string, clientNs string, destinationsToBeProcessed []string) []string {
+	actualServerIdentities := remoteRegistry.AdmiralCache.SourceToDestinations.Get(globalIdentifier)
+	processedClientClusters := remoteRegistry.AdmiralCache.ClientClusterNamespaceServerCache.Get(clusterName)
+
+	if actualServerIdentities == nil {
+		return nil
+	}
+
+	if processedClientClusters == nil || processedClientClusters.Get(clientNs) == nil {
+		destinationsToBeProcessed = actualServerIdentities
+	} else {
+		processedClientNamespaces := processedClientClusters.Get(clientNs)
+		for _, actualServerIdentity := range actualServerIdentities {
+			if processedClientNamespaces.Get(actualServerIdentity) == "" {
+				destinationsToBeProcessed = append(destinationsToBeProcessed, actualServerIdentity)
+			}
+		}
+	}
+	return destinationsToBeProcessed
+}
+
+func processDestinationsForSourceIdentity(ctx context.Context, remoteRegistry *RemoteRegistry, eventType admiral.EventType, hasNonMeshDestination bool, sourceClusters *common.Map, destinations []string, sourceIdentity string, modifySE ModifySEFunc) error {
+	var message string
+	var processingErrors error
+	counter := 1
+	totalDestinations := len(destinations)
+
+	for _, destinationIdentity := range destinations {
+		if strings.Contains(strings.ToLower(destinationIdentity), strings.ToLower(common.ServicesGatewayIdentity)) &&
+			!hasNonMeshDestination {
+			log.Infof(LogFormat, string(eventType), common.DependencyResourceType, sourceIdentity, "",
+				fmt.Sprintf("All destinations are MESH enabled. Skipping processing: %v", destinationIdentity))
+			continue
+		}
+
+		// In case of self on-boarding skip the update for the destination as it is the same as the source
+		if strings.EqualFold(sourceIdentity, destinationIdentity) {
+			log.Infof(LogFormat, string(eventType), common.DependencyResourceType, sourceIdentity, "",
+				fmt.Sprintf("Destination identity is same as source identity. Skipping processing: %v.", destinationIdentity))
+			continue
+		}
+
+		destinationClusters := remoteRegistry.AdmiralCache.IdentityClusterCache.Get(destinationIdentity)
+		log.Infof(LogFormat, string(eventType), common.DependencyResourceType, sourceIdentity, "", fmt.Sprintf("processing destination %d/%d destinationIdentity=%s", counter, totalDestinations, destinationIdentity))
+		clusters := remoteRegistry.AdmiralCache.IdentityClusterCache.Get(destinationIdentity)
+		if destinationClusters == nil || destinationClusters.Len() == 0 {
+			listOfSourceClusters := strings.Join(sourceClusters.GetKeys(), ",")
+			log.Infof(LogFormat, string(eventType), common.DependencyResourceType, sourceIdentity, listOfSourceClusters,
+				fmt.Sprintf("destinationClusters does not have any clusters. Skipping processing: %v.", destinationIdentity))
+			continue
+		}
+		if clusters == nil {
+			// When destination identity's cluster is not found, then
+			// skip calling modify SE because:
+			// 1. The destination identity might be NON MESH. Which means this error will always happen
+			//    and there is no point calling modifySE.
+			// 2. It could be that the IdentityClusterCache is not updated.
+			//    It is the deployment/rollout controllers responsibility to update the cache
+			//    without which the cache will always be empty. Now when deployment/rollout event occurs
+			//    that will result in calling modify SE and perform the same operations which this function is trying to do
+			log.Infof(LogFormat, string(eventType), common.DependencyResourceType, sourceIdentity, "",
+				fmt.Sprintf("no cluster found for destinationIdentity: %s. Skipping calling modifySE", destinationIdentity))
+			continue
+		}
+
+		for _, destinationClusterID := range clusters.GetKeys() {
+			message = fmt.Sprintf("processing cluster=%s for destinationIdentity=%s", destinationClusterID, destinationIdentity)
+			log.Infof(LogFormat, string(eventType), common.DependencyResourceType, sourceIdentity, "", message)
+			rc := remoteRegistry.GetRemoteController(destinationClusterID)
+			if rc == nil {
+				processingErrors = common.AppendError(processingErrors,
+					fmt.Errorf("no remote controller found in cache for cluster %s", destinationClusterID))
+				continue
+			}
+			ctx = context.WithValue(ctx, "clusterName", destinationClusterID)
+
+			if rc.DeploymentController != nil {
+				deploymentEnvMap := rc.DeploymentController.Cache.GetByIdentity(destinationIdentity)
+				if len(deploymentEnvMap) != 0 {
+					ctx = context.WithValue(ctx, "eventResourceType", common.Deployment)
+					ctx = context.WithValue(ctx, common.DependentClusterOverride, sourceClusters)
+					for env := range deploymentEnvMap {
+						message = fmt.Sprintf("calling modifySE for env=%s destinationIdentity=%s", env, destinationIdentity)
+						log.Infof(LogFormat, string(eventType), common.DependencyResourceType, sourceIdentity, "", message)
+						_, err := modifySE(ctx, eventType, env, destinationIdentity, remoteRegistry)
+						if err != nil {
+							message = fmt.Sprintf("error occurred in modifySE func for env=%s destinationIdentity=%s", env, destinationIdentity)
+							log.Errorf(LogErrFormat, string(eventType), common.DependencyResourceType, sourceIdentity, "", err.Error()+". "+message)
+							processingErrors = common.AppendError(processingErrors, err)
+						}
+					}
+					continue
+				}
+			}
+			if rc.RolloutController != nil {
+				rolloutEnvMap := rc.RolloutController.Cache.GetByIdentity(destinationIdentity)
+				if len(rolloutEnvMap) != 0 {
+					ctx = context.WithValue(ctx, "eventResourceType", common.Rollout)
+					ctx = context.WithValue(ctx, common.DependentClusterOverride, sourceClusters)
+					for env := range rolloutEnvMap {
+						message = fmt.Sprintf("calling modifySE for env=%s destinationIdentity=%s", env, destinationIdentity)
+						log.Infof(LogFormat, string(eventType), common.DependencyResourceType, sourceIdentity, "", message)
+						_, err := modifySE(ctx, eventType, env, destinationIdentity, remoteRegistry)
+						if err != nil {
+							message = fmt.Sprintf("error occurred in modifySE func for env=%s destinationIdentity=%s", env, destinationIdentity)
+							log.Errorf(LogErrFormat, string(eventType), common.DependencyResourceType, sourceIdentity, "", err.Error()+". "+message)
+							processingErrors = common.AppendError(processingErrors, err)
+						}
+					}
+					continue
+				}
+			}
+			log.Infof(LogFormat, string(eventType), common.DependencyResourceType, sourceIdentity, "", fmt.Sprintf("done processing destinationIdentity=%s", destinationIdentity))
+			log.Warnf(LogFormat, string(eventType), common.DependencyResourceType, sourceIdentity, "",
+				fmt.Sprintf("neither deployment or rollout controller initialized in cluster %s and destination identity %s", destinationClusterID, destinationIdentity))
+			counter++
+		}
+	}
+	return processingErrors
+}
+
+func getDestinationsToBeProcessed(eventType admiral.EventType,
+	updatedDependency *v1.Dependency, remoteRegistry *RemoteRegistry) ([]string, bool) {
+	updatedDestinations := make([]string, 0)
+	existingDestination := remoteRegistry.AdmiralCache.SourceToDestinations.Get(updatedDependency.Spec.Source)
+	var nonMeshEnabledExists bool
+	lookup := make(map[string]bool)
+	//if this is an update, build a look up table to process only the diff
+	if eventType == admiral.Update {
+		for _, dest := range existingDestination {
+			lookup[dest] = true
+		}
+	}
+
+	for _, destination := range updatedDependency.Spec.Destinations {
+		if !isIdentityMeshEnabled(destination, remoteRegistry) {
+			nonMeshEnabledExists = true
+		}
+		if ok := lookup[destination]; !ok {
+			updatedDestinations = append(updatedDestinations, destination)
+		}
+	}
+	return updatedDestinations, nonMeshEnabledExists
 }

--- a/admiral/pkg/controller/common/config.go
+++ b/admiral/pkg/controller/common/config.go
@@ -426,6 +426,12 @@ func EnableSWAwareNSCaches() bool {
 	return wrapper.params.EnableSWAwareNSCaches
 }
 
+func ClientInitiatedProcessingEnabled() bool {
+	wrapper.RLock()
+	defer wrapper.RUnlock()
+	return wrapper.params.ClientInitiatedProcessingEnabled
+}
+
 func GetIngressLBPolicy() string {
 	wrapper.RLock()
 	defer wrapper.RUnlock()

--- a/admiral/pkg/controller/common/types.go
+++ b/admiral/pkg/controller/common/types.go
@@ -26,6 +26,11 @@ type MapOfMapOfMaps struct {
 	mutex *sync.RWMutex
 }
 
+type MapOfMapOfMapsOfMaps struct {
+	cache map[string]*MapOfMapOfMaps
+	mutex *sync.RWMutex
+}
+
 type SidecarEgress struct {
 	Namespace string
 	FQDN      string
@@ -94,6 +99,7 @@ type AdmiralParams struct {
 	DisableIPGeneration                      bool
 	EnableActivePassive                      bool
 	EnableSWAwareNSCaches                    bool
+	ClientInitiatedProcessingEnabled         bool
 	ExportToIdentityList                     []string
 	ExportToMaxNamespaces                    int
 	EnableSyncIstioResourcesToSourceClusters bool
@@ -210,6 +216,13 @@ func NewMapOfMaps() *MapOfMaps {
 func NewMapOfMapOfMaps() *MapOfMapOfMaps {
 	n := new(MapOfMapOfMaps)
 	n.cache = make(map[string]*MapOfMaps)
+	n.mutex = &sync.RWMutex{}
+	return n
+}
+
+func NewMapOfMapOfMapOfMaps() *MapOfMapOfMapsOfMaps {
+	n := new(MapOfMapOfMapsOfMaps)
+	n.cache = make(map[string]*MapOfMapOfMaps)
 	n.mutex = &sync.RWMutex{}
 	return n
 }
@@ -472,4 +485,34 @@ type K8sObject struct {
 	Annotations map[string]string
 	Labels      map[string]string
 	Status      string
+}
+
+func (s *MapOfMapOfMapsOfMaps) Put(pkey string, skey string, tkey string, key, value string) {
+	defer s.mutex.Unlock()
+	s.mutex.Lock()
+	var mapOfMapOfMapsVal = s.cache[pkey]
+	if mapOfMapOfMapsVal == nil {
+		mapOfMapOfMapsVal = NewMapOfMapOfMaps()
+	}
+	mapOfMapOfMapsVal.Put(skey, tkey, key, value)
+	s.cache[pkey] = mapOfMapOfMapsVal
+}
+
+func (s *MapOfMapOfMapsOfMaps) PutMapofMapsofMaps(key string, value *MapOfMapOfMaps) {
+	defer s.mutex.Unlock()
+	s.mutex.Lock()
+	s.cache[key] = value
+}
+
+func (s *MapOfMapOfMapsOfMaps) Get(key string) *MapOfMapOfMaps {
+	s.mutex.RLock()
+	val := s.cache[key]
+	s.mutex.RUnlock()
+	return val
+}
+
+func (s *MapOfMapOfMapsOfMaps) Len() int {
+	defer s.mutex.RUnlock()
+	s.mutex.RLock()
+	return len(s.cache)
 }


### PR DESCRIPTION
* MESH-000: Implement client-initiated processing feature

- Added `ClientInitiatedProcessingEnabled` flag to enable/disable client-initiated processing.
- Introduced `processClientDependencyRecord` function to handle client dependencies.
- Refactored code to utilize `processDestinationsForSourceIdentity` for processing destinations.
- Added `ClientClusterNamespaceServerCache` to `RemoteRegistry` for caching client cluster namespaces.
- Updated deployment and rollout handlers to incorporate client-initiated processing logic.
- Created new data structures `MapOfMapOfMapsOfMaps` for enhanced caching capabilities.

### Checklist
🚨 Please review this repository's [contribution guidelines](./CONTRIBUTING.md).

- [ ] I've read and agree to the project's contribution guidelines.
- [ ] I'm requesting to **pull a topic/feature/bugfix branch**.
- [ ] I checked that my code additions will pass code linting checks and unit tests.
- [ ] I updated unit and integration tests (if applicable).
- [ ] I'm ready to notify the team of this contribution.

### Description
What does this change do and why?

[Link to related ISSUE]

Thank you!