### PR TITLE
MESH-5878: Admiral does not create envoy filter on client onboardings

### DIFF
--- a/admiral/pkg/clusters/dependency_handler.go
+++ b/admiral/pkg/clusters/dependency_handler.go
@@ -106,7 +106,9 @@ func (d *ProcessDestinationService) Process(ctx context.Context, dependency *v1.
 	}
 
 	destinations, hasNonMeshDestination := getDestinationsToBeProcessed(eventType, dependency, remoteRegistry)
-	log.Infof(LogFormat, string(eventType), common.DependencyResourceType, dependency.Name, "", fmt.Sprintf("found %d new destinations: %v", len(destinations), destinations))
+	id := common.GetIdentity(dependency.Labels, nil)
+	ctxLogger := common.GetCtxLogger(ctx, id, "-")
+	ctxLogger.Infof(LogFormat, string(eventType), common.DependencyResourceType, dependency.Name, "", fmt.Sprintf("found %d new destinations: %v", len(destinations), destinations))
 
 	// find source cluster for source identity
 	sourceClusters := remoteRegistry.AdmiralCache.IdentityClusterCache.Get(dependency.Spec.Source)
@@ -115,7 +117,7 @@ func (d *ProcessDestinationService) Process(ctx context.Context, dependency *v1.
 		// the rollout/deployment event hasn't gone through yet.
 		// This can be ignored, and not be added back to the dependency controller queue
 		// because it will be processed by the rollout/deployment controller
-		log.Infof(LogFormat, string(eventType), common.DependencyResourceType, dependency.Name, "", fmt.Sprintf("identity: %s, does not have any clusters. Skipping calling modifySE", dependency.Spec.Source))
+		ctxLogger.Infof(LogFormat, string(eventType), common.DependencyResourceType, dependency.Name, "", fmt.Sprintf("identity: %s, does not have any clusters. Skipping calling modifySE", dependency.Spec.Source))
 		return nil
 	}
 

--- a/admiral/pkg/clusters/dependency_handler.go
+++ b/admiral/pkg/clusters/dependency_handler.go
@@ -74,13 +74,13 @@ func (dh *DependencyHandler) HandleDependencyRecord(ctx context.Context, obj *v1
 		// This will be re-queued and retried
 		return handleDepRecordErrors
 	}
-	remoteRegistry.AdmiralCache.SourceToDestinations.put(obj)
-
 	// process routing policies.
 	err = dh.RoutingPolicyProcessor.ProcessDependency(ctx, eventType, obj)
 	if err != nil {
 		log.Errorf(LogErrFormat, string(eventType), common.DependencyResourceType, obj.Name, "", fmt.Sprintf("error processing routing policies %v", err))
 	}
+
+	remoteRegistry.AdmiralCache.SourceToDestinations.put(obj)
 
 	return handleDepRecordErrors
 }

--- a/admiral/pkg/clusters/dependency_handler.go
+++ b/admiral/pkg/clusters/dependency_handler.go
@@ -61,12 +61,6 @@ func (dh *DependencyHandler) HandleDependencyRecord(ctx context.Context, obj *v1
 
 	var handleDepRecordErrors error
 
-	// process routing policies.
-	err = dh.RoutingPolicyProcessor.ProcessDependency(ctx, eventType, obj)
-	if err != nil {
-		log.Errorf(LogErrFormat, string(eventType), common.DependencyResourceType, obj.Name, "", fmt.Sprintf("error processing routing policies %v", err))
-	}
-
 	// Generate SE/DR/VS for all newly added destination services in the source's cluster
 	err = dh.DestinationServiceProcessor.Process(ctx,
 		obj,
@@ -80,8 +74,14 @@ func (dh *DependencyHandler) HandleDependencyRecord(ctx context.Context, obj *v1
 		// This will be re-queued and retried
 		return handleDepRecordErrors
 	}
-
 	remoteRegistry.AdmiralCache.SourceToDestinations.put(obj)
+
+	// process routing policies.
+	err = dh.RoutingPolicyProcessor.ProcessDependency(ctx, eventType, obj)
+	if err != nil {
+		log.Errorf(LogErrFormat, string(eventType), common.DependencyResourceType, obj.Name, "", fmt.Sprintf("error processing routing policies %v", err))
+	}
+
 	return handleDepRecordErrors
 }
 

--- a/admiral/pkg/clusters/dependency_handler.go
+++ b/admiral/pkg/clusters/dependency_handler.go
@@ -20,6 +20,7 @@ type DependencyHandler struct {
 	RemoteRegistry              *RemoteRegistry
 	DepController               *admiral.DependencyController
 	DestinationServiceProcessor DestinationServiceProcessor
+	RoutingPolicyProcessor      RoutingPolicyProcessor
 }
 
 func (dh *DependencyHandler) Added(ctx context.Context, obj *v1.Dependency) error {
@@ -73,6 +74,9 @@ func (dh *DependencyHandler) HandleDependencyRecord(ctx context.Context, obj *v1
 		// This will be re-queued and retried
 		return handleDepRecordErrors
 	}
+
+	// process routing policies
+	_ = dh.RoutingPolicyProcessor.ProcessDependency(ctx, eventType, obj)
 
 	remoteRegistry.AdmiralCache.SourceToDestinations.put(obj)
 	return handleDepRecordErrors

--- a/admiral/pkg/clusters/dependency_handler.go
+++ b/admiral/pkg/clusters/dependency_handler.go
@@ -61,6 +61,12 @@ func (dh *DependencyHandler) HandleDependencyRecord(ctx context.Context, obj *v1
 
 	var handleDepRecordErrors error
 
+	// process routing policies.
+	err = dh.RoutingPolicyProcessor.ProcessDependency(ctx, eventType, obj)
+	if err != nil {
+		log.Errorf(LogErrFormat, string(eventType), common.DependencyResourceType, obj.Name, "", fmt.Sprintf("error processing routing policies %v", err))
+	}
+
 	// Generate SE/DR/VS for all newly added destination services in the source's cluster
 	err = dh.DestinationServiceProcessor.Process(ctx,
 		obj,
@@ -74,9 +80,6 @@ func (dh *DependencyHandler) HandleDependencyRecord(ctx context.Context, obj *v1
 		// This will be re-queued and retried
 		return handleDepRecordErrors
 	}
-
-	// process routing policies
-	_ = dh.RoutingPolicyProcessor.ProcessDependency(ctx, eventType, obj)
 
 	remoteRegistry.AdmiralCache.SourceToDestinations.put(obj)
 	return handleDepRecordErrors

--- a/admiral/pkg/clusters/dependency_handler_test.go
+++ b/admiral/pkg/clusters/dependency_handler_test.go
@@ -583,10 +583,16 @@ func TestGetDestinationDiff(t *testing.T) {
 	var (
 		identityClusterCacheWithOnlyFoo        = common.NewMapOfMaps()
 		identityClusterCacheWithAllMeshEnabled = common.NewMapOfMaps()
+		identityClusterCacheMultiple           = common.NewMapOfMaps()
 	)
 	identityClusterCacheWithOnlyFoo.Put("foo", "cluster1", "cluster1")
 	identityClusterCacheWithAllMeshEnabled.Put("foo", "cluster1", "cluster1")
 	identityClusterCacheWithAllMeshEnabled.Put("bar", "cluster1", "cluster1")
+
+	identityClusterCacheMultiple.Put("foo", "cluster1", "cluster1")
+	identityClusterCacheMultiple.Put("bar", "cluster1", "cluster1")
+	identityClusterCacheMultiple.Put("baz", "cluster1", "cluster1")
+
 	testCases := []struct {
 		name                     string
 		eventType                admiral.EventType

--- a/admiral/pkg/clusters/envoyfilter_test.go
+++ b/admiral/pkg/clusters/envoyfilter_test.go
@@ -30,8 +30,6 @@ import (
 func TestCreateOrUpdateEnvoyFilter(t *testing.T) {
 	registry := getRegistry("1.13,1.17")
 
-	handler := RoutingPolicyHandler{}
-
 	rpFilterCache := &routingPolicyFilterCache{}
 	rpFilterCache.filterCache = make(map[string]map[string]map[string]string)
 	rpFilterCache.mutex = &sync.Mutex{}
@@ -88,8 +86,6 @@ func TestCreateOrUpdateEnvoyFilter(t *testing.T) {
 	// foo is dependent upon bar and bar has a deployment in the same cluster.
 	registry.AdmiralCache.IdentityDependencyCache.Put("foo", "bar", "bar")
 	registry.AdmiralCache.IdentityClusterCache.Put("bar", remoteController.ClusterID, remoteController.ClusterID)
-
-	handler.RemoteRegistry = registry
 
 	routingPolicyFoo := &v1.RoutingPolicy{
 		TypeMeta: metav1.TypeMeta{},

--- a/admiral/pkg/clusters/registry_test.go
+++ b/admiral/pkg/clusters/registry_test.go
@@ -273,6 +273,7 @@ func TestAdded(t *testing.T) {
 		RemoteRegistry:              rr,
 		DepController:               d,
 		DestinationServiceProcessor: &MockDestinationServiceProcessor{},
+		RoutingPolicyProcessor:      &MockPolicyProcessor{},
 	}
 
 	depData := v1.Dependency{

--- a/admiral/pkg/clusters/routingpolicy_handler.go
+++ b/admiral/pkg/clusters/routingpolicy_handler.go
@@ -3,6 +3,7 @@ package clusters
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 
 	commonUtil "github.com/istio-ecosystem/admiral/admiral/pkg/util"
@@ -15,51 +16,195 @@ import (
 )
 
 type RoutingPolicyHandler struct {
+	RemoteRegistry       *RemoteRegistry
+	ClusterID            string
+	RoutingPolicyService RoutingPolicyProcessor
+}
+
+func NewRoutingPolicyHandler(rr *RemoteRegistry, cId string, rpProcessor RoutingPolicyProcessor) *RoutingPolicyHandler {
+	return &RoutingPolicyHandler{RemoteRegistry: rr, ClusterID: cId, RoutingPolicyService: rpProcessor}
+}
+
+type RoutingPolicyProcessor interface {
+	ProcessAddOrUpdate(ctx context.Context, eventType admiral.EventType, newRP *v1.RoutingPolicy, oldRP *v1.RoutingPolicy, dependents map[string]string) error
+	ProcessDependency(ctx context.Context, eventType admiral.EventType, dependency *v1.Dependency) error
+	Delete(ctx context.Context, eventType admiral.EventType, routingPolicy *v1.RoutingPolicy) error
+}
+
+type RoutingPolicyService struct {
 	RemoteRegistry *RemoteRegistry
-	ClusterID      string
 }
 
-type routingPolicyCache struct {
-	// map of routing policies key=environment.identity, value: RoutingPolicy object
-	// only one routing policy per identity + env is allowed
-	identityCache map[string]*v1.RoutingPolicy
-	mutex         *sync.Mutex
-}
-
-func (r *routingPolicyCache) Delete(identity string, environment string) {
-	defer r.mutex.Unlock()
-	r.mutex.Lock()
-	key := common.ConstructRoutingPolicyKey(environment, identity)
-	if _, ok := r.identityCache[key]; ok {
-		log.Infof("deleting RoutingPolicy with key=%s from global RoutingPolicy cache", key)
-		delete(r.identityCache, key)
+func (r *RoutingPolicyService) ProcessAddOrUpdate(ctx context.Context, eventType admiral.EventType, newRP *v1.RoutingPolicy, oldRP *v1.RoutingPolicy, dependents map[string]string) error {
+	var err error
+	for _, remoteController := range r.RemoteRegistry.remoteControllers {
+		if !common.DoRoutingPolicyForCluster(remoteController.ClusterID) {
+			log.Warnf(LogFormat, eventType, "routingpolicy", newRP.Name, remoteController.ClusterID, "RoutingPolicy disabled for cluster")
+			continue
+		}
+		for _, dependent := range dependents {
+			// Check if the dependent exists in this remoteCluster. If so, we create an envoyFilter with dependent identity as workload selector
+			if _, ok := r.RemoteRegistry.AdmiralCache.IdentityClusterCache.Get(dependent).Copy()[remoteController.ClusterID]; ok {
+				_, err1 := createOrUpdateEnvoyFilter(ctx, remoteController, newRP, eventType, dependent, r.RemoteRegistry.AdmiralCache)
+				if err1 != nil {
+					log.Errorf(LogErrFormat, eventType, "routingpolicy", newRP.Name, remoteController.ClusterID, err)
+					err = common.AppendError(err, err1)
+				} else {
+					log.Infof(LogFormat, eventType, "routingpolicy	", newRP.Name, remoteController.ClusterID, "created envoyfilters")
+					id := common.GetRoutingPolicyIdentity(newRP)
+					if oldRP != nil {
+						oldEnv := common.GetRoutingPolicyEnv(oldRP)
+						r.RemoteRegistry.AdmiralCache.RoutingPolicyCache.Delete(id, oldEnv, oldRP.Name)
+					}
+					env := common.GetRoutingPolicyEnv(newRP)
+					r.RemoteRegistry.AdmiralCache.RoutingPolicyCache.Put(id, env, newRP.Name, newRP)
+				}
+			}
+		}
 	}
+	return err
 }
 
-func (r *routingPolicyCache) GetFromIdentity(identity string, environment string) *v1.RoutingPolicy {
-	defer r.mutex.Unlock()
-	r.mutex.Lock()
-	return r.identityCache[common.ConstructRoutingPolicyKey(environment, identity)]
-}
+func (r *RoutingPolicyService) ProcessDependency(ctx context.Context, eventType admiral.EventType, dependency *v1.Dependency) error {
+	newDestinations, _ := getDestinationsToBeProcessed(eventType, dependency, r.RemoteRegistry)
 
-func (r *routingPolicyCache) Put(rp *v1.RoutingPolicy) error {
-	if rp == nil || rp.Name == "" {
-		// no RoutingPolicy, throw error
-		return errors.New("cannot add an empty RoutingPolicy to the cache")
+	// for each destination, identify the newRP.
+	for _, dependent := range newDestinations {
+		// if the dependent is in the mesh, then get the newRP
+		policies := r.RemoteRegistry.AdmiralCache.RoutingPolicyCache.GetForIdentity(dependent)
+		for _, rp := range policies {
+			err := r.ProcessAddOrUpdate(ctx, eventType, rp, nil, map[string]string{dependent: dependency.Spec.Source})
+			if err != nil {
+				log.Errorf(LogErrFormat, eventType, "routingpolicy", rp.Name, "",
+					fmt.Sprintf("failed to process routing policy for new destination=%s in delta update", dependent))
+				return err
+			}
+			log.Infof(LogFormat, eventType, "routingpolicy", rp.Name, "",
+				fmt.Sprintf("finished processing routing policy for new destination=%s in delta update", dependent))
+		}
 	}
-	if rp.Labels == nil {
-		return errors.New("labels empty in RoutingPolicy")
-	}
-	defer r.mutex.Unlock()
-	r.mutex.Lock()
-	var rpIdentity = rp.Labels[common.GetRoutingPolicyLabel()]
-	var rpEnv = common.GetRoutingPolicyEnv(rp)
-
-	log.Infof("Adding RoutingPolicy with name %v to RoutingPolicy cache. LabelMatch=%v env=%v", rp.Name, rpIdentity, rpEnv)
-	key := common.ConstructRoutingPolicyKey(rpEnv, rpIdentity)
-	r.identityCache[key] = rp
 
 	return nil
+}
+
+func (r *RoutingPolicyService) Delete(ctx context.Context, eventType admiral.EventType, routingPolicy *v1.RoutingPolicy) error {
+	identity := common.GetRoutingPolicyIdentity(routingPolicy)
+	env := common.GetRoutingPolicyEnv(routingPolicy)
+	key := routingPolicy.Name + identity + env
+	if r.RemoteRegistry == nil || r.RemoteRegistry.AdmiralCache == nil || r.RemoteRegistry.AdmiralCache.RoutingPolicyFilterCache == nil {
+		log.Infof(LogFormat, eventType, "routingpolicy", routingPolicy.Name, "", "skipping delete event as cache is nil")
+		return nil
+	}
+	clusterIdFilterMap := r.RemoteRegistry.AdmiralCache.RoutingPolicyFilterCache.Get(key) // RoutingPolicyFilterCache key=rpname+rpidentity+environment of the routingPolicy, value is a map [clusterId -> map [filterName -> filterNameSpace]]
+	var err error
+	for _, rc := range r.RemoteRegistry.remoteControllers {
+		if !common.DoRoutingPolicyForCluster(rc.ClusterID) {
+			log.Warnf(LogFormat, eventType, "routingpolicy", routingPolicy.Name, rc.ClusterID, "RoutingPolicy disabled for cluster")
+			continue
+		}
+		if filterMap, ok := clusterIdFilterMap[rc.ClusterID]; ok {
+			for filter, filterNs := range filterMap {
+				log.Infof(LogFormat, eventType, "envoyfilter", filter, rc.ClusterID, "deleting")
+				err1 := rc.RoutingPolicyController.IstioClient.NetworkingV1alpha3().EnvoyFilters(filterNs).Delete(ctx, filter, metaV1.DeleteOptions{})
+				if err1 != nil {
+					log.Errorf(LogErrFormat, eventType, "envoyfilter", filter, rc.ClusterID, err1)
+					err = common.AppendError(err, err1)
+				}
+			}
+		}
+	}
+	if err == nil {
+		log.Infof(LogFormat, eventType, "routingPolicy", fmt.Sprintf("%s.%s.%s", identity, env, routingPolicy.Name), "", "deleting from cache")
+		r.RemoteRegistry.AdmiralCache.RoutingPolicyCache.Delete(identity, env, routingPolicy.Name)
+		r.RemoteRegistry.AdmiralCache.RoutingPolicyFilterCache.Delete(key)
+	}
+	return err
+}
+
+func NewRoutingPolicyProcessor(remoteRegistry *RemoteRegistry) RoutingPolicyProcessor {
+	return &RoutingPolicyService{RemoteRegistry: remoteRegistry}
+}
+
+type routingPolicyCacheEntry struct {
+	// key: env, value: map [ key: name, value: routingPolicy]
+	policiesByEnv map[string]map[string]*v1.RoutingPolicy
+}
+
+type RoutingPolicyCache struct {
+	// key: identity of the asset
+	// value: routingPolicyCacheEntry
+	entries map[string]*routingPolicyCacheEntry
+	mutex   *sync.Mutex
+}
+
+func NewRoutingPolicyCache() *RoutingPolicyCache {
+	entries := make(map[string]*routingPolicyCacheEntry)
+	return &RoutingPolicyCache{entries: entries, mutex: &sync.Mutex{}}
+}
+
+func (r *RoutingPolicyCache) GetForIdentity(identity string) []*v1.RoutingPolicy {
+	defer r.mutex.Unlock()
+	r.mutex.Lock()
+	if r.entries[identity] == nil {
+		return []*v1.RoutingPolicy{}
+	}
+	policies := make([]*v1.RoutingPolicy, 0)
+	for _, envMap := range r.entries[identity].policiesByEnv {
+		for _, rp := range envMap {
+			policies = append(policies, rp)
+		}
+	}
+	return policies
+}
+
+func (r *RoutingPolicyCache) Get(identity string, env string, name string) *v1.RoutingPolicy {
+
+	defer r.mutex.Unlock()
+	r.mutex.Lock()
+	if (r.entries[identity] == nil) ||
+		(r.entries[identity].policiesByEnv == nil) ||
+		(r.entries[identity].policiesByEnv[env] == nil) ||
+		(r.entries[identity].policiesByEnv[env][name] == nil) {
+		return nil
+	}
+	return r.entries[identity].policiesByEnv[env][name]
+}
+
+func (r *RoutingPolicyCache) Put(identity string, env string, name string, rp *v1.RoutingPolicy) {
+	if rp == nil {
+		return
+	}
+	defer r.mutex.Unlock()
+	r.mutex.Lock()
+	if r.entries[identity] == nil {
+		r.entries[identity] = &routingPolicyCacheEntry{policiesByEnv: make(map[string]map[string]*v1.RoutingPolicy)}
+	}
+	if r.entries[identity].policiesByEnv[env] == nil {
+		r.entries[identity].policiesByEnv[env] = make(map[string]*v1.RoutingPolicy)
+	}
+	r.entries[identity].policiesByEnv[env][name] = rp
+}
+
+func (r *RoutingPolicyCache) Delete(identity string, env string, name string) {
+	if commonUtil.IsAdmiralReadOnly() {
+		log.Infof(LogFormat, admiral.Delete, "routingpolicy", fmt.Sprintf("%s.%s.%s", identity, env, name), "", "skipping read-only mode")
+		return
+	}
+	if common.GetEnableRoutingPolicy() {
+		defer r.mutex.Unlock()
+		r.mutex.Lock()
+		if r.entries[identity] != nil &&
+			r.entries[identity].policiesByEnv != nil &&
+			r.entries[identity].policiesByEnv[env] != nil &&
+			r.entries[identity].policiesByEnv[env][name] != nil {
+			delete(r.entries[identity].policiesByEnv[env], name)
+			if len(r.entries[identity].policiesByEnv[env]) == 0 {
+				delete(r.entries[identity].policiesByEnv, env)
+			}
+		}
+	} else {
+		log.Infof(LogFormat, admiral.Delete, "routingpolicy", fmt.Sprintf("%s.%s.%s", identity, env, name), "", "routingpolicy disabled")
+	}
 }
 
 type routingPolicyFilterCache struct {
@@ -116,7 +261,7 @@ func (r RoutingPolicyHandler) Added(ctx context.Context, obj *v1.RoutingPolicy) 
 		if common.ShouldIgnoreResource(obj.ObjectMeta) {
 			log.Infof("op=%s type=%v name=%v namespace=%s cluster=%s message=%s", "admiralIoIgnoreAnnotationCheck", common.RoutingPolicyResourceType,
 				obj.Name, obj.Namespace, "", "Value=true")
-			log.Infof(LogFormat, "success", "routingpolicy", obj.Name, "", "Ignored the RoutingPolicy because of the annotation")
+			log.Infof(LogFormat, "success", "routingpolicy", obj.Name, "", "Ignored the RoutingPolicy because of the annotation or label")
 			return nil
 		}
 		dependents := getDependents(obj, r)
@@ -124,7 +269,7 @@ func (r RoutingPolicyHandler) Added(ctx context.Context, obj *v1.RoutingPolicy) 
 			log.Info("No dependents found for Routing Policy - ", obj.Name)
 			return nil
 		}
-		err := r.processroutingPolicy(ctx, dependents, obj, admiral.Add)
+		err := r.RoutingPolicyService.ProcessAddOrUpdate(ctx, admiral.Add, obj, nil, dependents)
 		if err != nil {
 			log.Errorf(LogErrFormat, admiral.Update, "routingpolicy", obj.Name, "", "failed to process routing policy")
 			return err
@@ -136,55 +281,32 @@ func (r RoutingPolicyHandler) Added(ctx context.Context, obj *v1.RoutingPolicy) 
 	return nil
 }
 
-func (r RoutingPolicyHandler) processroutingPolicy(ctx context.Context, dependents map[string]string, routingPolicy *v1.RoutingPolicy, eventType admiral.EventType) error {
-	var err error
-	for _, remoteController := range r.RemoteRegistry.remoteControllers {
-		if !common.DoRoutingPolicyForCluster(remoteController.ClusterID) {
-			log.Warnf(LogFormat, eventType, "routingpolicy", routingPolicy.Name, remoteController.ClusterID, "RoutingPolicy disabled for cluster")
-			continue
-		}
-		for _, dependent := range dependents {
-			// Check if the dependent exists in this remoteCluster. If so, we create an envoyFilter with dependent identity as workload selector
-			if _, ok := r.RemoteRegistry.AdmiralCache.IdentityClusterCache.Get(dependent).Copy()[remoteController.ClusterID]; ok {
-				_, err1 := createOrUpdateEnvoyFilter(ctx, remoteController, routingPolicy, eventType, dependent, r.RemoteRegistry.AdmiralCache)
-				if err1 != nil {
-					log.Errorf(LogErrFormat, eventType, "routingpolicy", routingPolicy.Name, remoteController.ClusterID, err)
-					err = common.AppendError(err, err1)
-				} else {
-					log.Infof(LogFormat, eventType, "routingpolicy	", routingPolicy.Name, remoteController.ClusterID, "created envoyfilters")
-				}
-			}
-		}
-	}
-	return err
-}
-
-func (r RoutingPolicyHandler) Updated(ctx context.Context, obj *v1.RoutingPolicy) error {
+func (r RoutingPolicyHandler) Updated(ctx context.Context, newRP *v1.RoutingPolicy, oldRP *v1.RoutingPolicy) error {
 	if commonUtil.IsAdmiralReadOnly() {
 		log.Infof(LogFormat, admiral.Update, "routingpolicy", "", "", "skipping read-only mode")
 		return nil
 	}
 	if common.GetEnableRoutingPolicy() {
-		if common.ShouldIgnoreResource(obj.ObjectMeta) {
+		if common.ShouldIgnoreResource(newRP.ObjectMeta) {
 			log.Infof("op=%s type=%v name=%v namespace=%s cluster=%s message=%s", "admiralIoIgnoreAnnotationCheck", common.RoutingPolicyResourceType,
-				obj.Name, obj.Namespace, "", "Value=true")
-			log.Infof(LogFormat, admiral.Update, "routingpolicy", obj.Name, "", "Ignored the RoutingPolicy because of the annotation")
+				newRP.Name, newRP.Namespace, "", "Value=true")
+			log.Infof(LogFormat, admiral.Update, "routingpolicy", newRP.Name, "", "Ignored the RoutingPolicy because of the annotation or label")
 			// We need to process this as a delete event.
-			r.Deleted(ctx, obj)
+			r.Deleted(ctx, newRP)
 			return nil
 		}
-		dependents := getDependents(obj, r)
+		dependents := getDependents(newRP, r)
 		if len(dependents) == 0 {
 			return nil
 		}
-		err := r.processroutingPolicy(ctx, dependents, obj, admiral.Update)
+		err := r.RoutingPolicyService.ProcessAddOrUpdate(ctx, admiral.Update, newRP, oldRP, dependents)
 		if err != nil {
-			log.Errorf(LogErrFormat, admiral.Update, "routingpolicy", obj.Name, "", "failed to process routing policy")
+			log.Errorf(LogErrFormat, admiral.Update, "routingpolicy", newRP.Name, "", "failed to process routing policy")
 			return err
 		}
-		log.Infof(LogFormat, admiral.Update, "routingpolicy", obj.Name, "", "updated routing policy")
+		log.Infof(LogFormat, admiral.Update, "routingpolicy", newRP.Name, "", "updated routing policy")
 	} else {
-		log.Infof(LogFormat, admiral.Update, "routingpolicy", obj.Name, "", "routingpolicy disabled")
+		log.Infof(LogFormat, admiral.Update, "routingpolicy", newRP.Name, "", "routingpolicy disabled")
 	}
 	return nil
 }
@@ -207,43 +329,9 @@ func getDependents(obj *v1.RoutingPolicy, r RoutingPolicyHandler) map[string]str
 Deleted - deletes the envoyFilters for the routingPolicy when delete event received for routing policy
 */
 func (r RoutingPolicyHandler) Deleted(ctx context.Context, obj *v1.RoutingPolicy) error {
-	err := r.deleteEnvoyFilters(ctx, obj, admiral.Delete)
+	err := r.RoutingPolicyService.Delete(ctx, admiral.Delete, obj)
 	if err != nil {
 		log.Infof(LogFormat, admiral.Delete, "routingpolicy", obj.Name, "", "deleted envoy filter for routing policy")
-	}
-	return err
-}
-
-func (r RoutingPolicyHandler) deleteEnvoyFilters(ctx context.Context, obj *v1.RoutingPolicy, eventType admiral.EventType) error {
-	key := obj.Name + common.GetRoutingPolicyIdentity(obj) + common.GetRoutingPolicyEnv(obj)
-	if r.RemoteRegistry == nil || r.RemoteRegistry.AdmiralCache == nil || r.RemoteRegistry.AdmiralCache.RoutingPolicyFilterCache == nil {
-		log.Infof(LogFormat, eventType, "routingpolicy", obj.Name, "", "skipping delete event as cache is nil")
-		return nil
-	}
-	clusterIdFilterMap := r.RemoteRegistry.AdmiralCache.RoutingPolicyFilterCache.Get(key) // RoutingPolicyFilterCache key=rpname+rpidentity+environment of the routingPolicy, value is a map [clusterId -> map [filterName -> filterNameSpace]]
-	var err error
-	for _, rc := range r.RemoteRegistry.remoteControllers {
-		if rc != nil {
-			if !common.DoRoutingPolicyForCluster(rc.ClusterID) {
-				log.Warnf(LogFormat, eventType, "routingpolicy", obj.Name, rc.ClusterID, "RoutingPolicy disabled for cluster")
-				continue
-			}
-			if filterMap, ok := clusterIdFilterMap[rc.ClusterID]; ok {
-				for filter, filterNs := range filterMap {
-					log.Infof(LogFormat, eventType, "envoyfilter", filter, rc.ClusterID, "deleting")
-					err1 := rc.RoutingPolicyController.IstioClient.NetworkingV1alpha3().EnvoyFilters(filterNs).Delete(ctx, filter, metaV1.DeleteOptions{})
-					if err1 != nil {
-						log.Errorf(LogErrFormat, eventType, "envoyfilter", filter, rc.ClusterID, err1)
-						err = common.AppendError(err, err1)
-					} else {
-						log.Infof(LogFormat, eventType, "envoyfilter", filter, rc.ClusterID, "deleting from cache")
-					}
-				}
-			}
-		}
-	}
-	if err == nil {
-		r.RemoteRegistry.AdmiralCache.RoutingPolicyFilterCache.Delete(key)
 	}
 	return err
 }

--- a/admiral/pkg/clusters/routingpolicy_handler.go
+++ b/admiral/pkg/clusters/routingpolicy_handler.go
@@ -40,7 +40,8 @@ func (r *RoutingPolicyService) ProcessAddOrUpdate(ctx context.Context, eventType
 	id := common.GetRoutingPolicyIdentity(newRP)
 	env := common.GetRoutingPolicyEnv(newRP)
 	ctxLogger := common.GetCtxLogger(ctx, id, env)
-	ctxLogger.Infof(LogFormat, eventType, common.RoutingPolicyResourceType, newRP.Name, "-", "start of processing routing policy")
+	ctxLogger.Infof(LogFormat, eventType, common.RoutingPolicyResourceType, newRP.Name, "-",
+		fmt.Sprintf("start of processing routing policy, dependents=[%v]", dependents))
 	var err error
 	defer util.LogElapsedTime("ProcessAddOrUpdateRoutingPolicy", id, env, "-")()
 	for _, remoteController := range r.RemoteRegistry.remoteControllers {
@@ -66,7 +67,8 @@ func (r *RoutingPolicyService) ProcessAddOrUpdate(ctx context.Context, eventType
 			}
 		}
 	}
-	ctxLogger.Infof(LogFormat, eventType, common.RoutingPolicyResourceType, newRP.Name, "-", "end of processing routing policy")
+	ctxLogger.Infof(LogFormat, eventType, common.RoutingPolicyResourceType, newRP.Name, "-",
+		fmt.Sprintf("end of processing routing policy, dependents=[%v]", dependents))
 	return err
 }
 
@@ -75,7 +77,8 @@ func (r *RoutingPolicyService) ProcessDependency(ctx context.Context, eventType 
 	env := common.GetEnvFromMetadata(dependency.Annotations, dependency.Labels, nil)
 	ctxLogger := common.GetCtxLogger(ctx, dependency.Name, env)
 	defer util.LogElapsedTime("ProcessDependencyUpdateForRoutingPolicy", dependency.Spec.Source, env, "-")()
-	ctxLogger.Infof(LogFormat, eventType, common.RoutingPolicyResourceType, dependency.Spec.Source, "-", "start of processing dependency update for routing policy")
+	ctxLogger.Infof(LogFormat, eventType, common.RoutingPolicyResourceType, dependency.Spec.Source, "-",
+		fmt.Sprintf("start of processing dependency update for routing policy, newDestinations=[%v]", newDestinations))
 	// for each destination, identify the newRP.
 	for _, dependent := range newDestinations {
 		// if the dependent is in the mesh, then get the newRP
@@ -91,7 +94,8 @@ func (r *RoutingPolicyService) ProcessDependency(ctx context.Context, eventType 
 				fmt.Sprintf("finished processing routing policy for new destination=%s in delta update", dependent))
 		}
 	}
-	ctxLogger.Infof(LogFormat, eventType, common.RoutingPolicyResourceType, dependency.Spec.Source, "-", "end of processing dependency update for routing policy")
+	ctxLogger.Infof(LogFormat, eventType, common.RoutingPolicyResourceType, dependency.Spec.Source, "-",
+		fmt.Sprintf("end of processing dependency update for routing policy, newDestinations=[%v]", newDestinations))
 	return nil
 }
 
@@ -100,7 +104,7 @@ func (r *RoutingPolicyService) Delete(ctx context.Context, eventType admiral.Eve
 	env := common.GetRoutingPolicyEnv(routingPolicy)
 	ctxLogger := common.GetCtxLogger(ctx, identity, env)
 	defer util.LogElapsedTime("DeleteRoutingPolicy", identity, env, "-")()
-	ctxLogger.Debugf(LogFormat, eventType, common.RoutingPolicyResourceType, routingPolicy.Name, "-", "start of delete for routing policy")
+	ctxLogger.Infof(LogFormat, eventType, common.RoutingPolicyResourceType, routingPolicy.Name, "-", "start of delete for routing policy")
 	key := routingPolicy.Name + identity + env
 	if r.RemoteRegistry == nil || r.RemoteRegistry.AdmiralCache == nil || r.RemoteRegistry.AdmiralCache.RoutingPolicyFilterCache == nil {
 		ctxLogger.Infof(LogFormat, eventType, common.RoutingPolicyResourceType, routingPolicy.Name, "", "skipping delete event as cache is nil")
@@ -130,7 +134,7 @@ func (r *RoutingPolicyService) Delete(ctx context.Context, eventType admiral.Eve
 		r.RemoteRegistry.AdmiralCache.RoutingPolicyCache.Delete(identity, env, routingPolicy.Name)
 		r.RemoteRegistry.AdmiralCache.RoutingPolicyFilterCache.Delete(key)
 	}
-	ctxLogger.Debugf(LogFormat, eventType, common.RoutingPolicyResourceType, routingPolicy.Name, "-", "end of delete for routing policy")
+	ctxLogger.Infof(LogFormat, eventType, common.RoutingPolicyResourceType, routingPolicy.Name, "-", "end of delete for routing policy")
 	return err
 }
 

--- a/admiral/pkg/clusters/routingpolicy_handler.go
+++ b/admiral/pkg/clusters/routingpolicy_handler.go
@@ -40,9 +40,9 @@ func (r *RoutingPolicyService) ProcessAddOrUpdate(ctx context.Context, eventType
 	id := common.GetRoutingPolicyIdentity(newRP)
 	env := common.GetRoutingPolicyEnv(newRP)
 	ctxLogger := common.GetCtxLogger(ctx, id, env)
-	ctxLogger.Debugf(LogFormat, eventType, common.RoutingPolicyResourceType, newRP.Name, "-", "start of processing routing policy")
+	ctxLogger.Infof(LogFormat, eventType, common.RoutingPolicyResourceType, newRP.Name, "-", "start of processing routing policy")
 	var err error
-	defer util.LogElapsedTime("ProcessAddOrUpdateRoutingPolicy", id, env, "-")
+	defer util.LogElapsedTime("ProcessAddOrUpdateRoutingPolicy", id, env, "-")()
 	for _, remoteController := range r.RemoteRegistry.remoteControllers {
 		if !common.DoRoutingPolicyForCluster(remoteController.ClusterID) {
 			ctxLogger.Warnf(LogFormat, eventType, common.RoutingPolicyResourceType, newRP.Name, remoteController.ClusterID, "processing disabled for cluster")
@@ -66,7 +66,7 @@ func (r *RoutingPolicyService) ProcessAddOrUpdate(ctx context.Context, eventType
 			}
 		}
 	}
-	ctxLogger.Debugf(LogFormat, eventType, common.RoutingPolicyResourceType, newRP.Name, "-", "end of processing routing policy")
+	ctxLogger.Infof(LogFormat, eventType, common.RoutingPolicyResourceType, newRP.Name, "-", "end of processing routing policy")
 	return err
 }
 
@@ -74,8 +74,8 @@ func (r *RoutingPolicyService) ProcessDependency(ctx context.Context, eventType 
 	newDestinations, _ := getDestinationsToBeProcessed(eventType, dependency, r.RemoteRegistry)
 	env := common.GetEnvFromMetadata(dependency.Annotations, dependency.Labels, nil)
 	ctxLogger := common.GetCtxLogger(ctx, dependency.Name, env)
-	defer util.LogElapsedTime("ProcessDependencyUpdateForRoutingPolicy", dependency.Spec.Source, env, "-")
-	ctxLogger.Debugf(LogFormat, eventType, common.RoutingPolicyResourceType, dependency.Spec.Source, "-", "start of processing dependency update for routing policy")
+	defer util.LogElapsedTime("ProcessDependencyUpdateForRoutingPolicy", dependency.Spec.Source, env, "-")()
+	ctxLogger.Infof(LogFormat, eventType, common.RoutingPolicyResourceType, dependency.Spec.Source, "-", "start of processing dependency update for routing policy")
 	// for each destination, identify the newRP.
 	for _, dependent := range newDestinations {
 		// if the dependent is in the mesh, then get the newRP
@@ -91,7 +91,7 @@ func (r *RoutingPolicyService) ProcessDependency(ctx context.Context, eventType 
 				fmt.Sprintf("finished processing routing policy for new destination=%s in delta update", dependent))
 		}
 	}
-	ctxLogger.Debugf(LogFormat, eventType, common.RoutingPolicyResourceType, dependency.Spec.Source, "-", "end of processing dependency update for routing policy")
+	ctxLogger.Infof(LogFormat, eventType, common.RoutingPolicyResourceType, dependency.Spec.Source, "-", "end of processing dependency update for routing policy")
 	return nil
 }
 
@@ -99,7 +99,7 @@ func (r *RoutingPolicyService) Delete(ctx context.Context, eventType admiral.Eve
 	identity := common.GetRoutingPolicyIdentity(routingPolicy)
 	env := common.GetRoutingPolicyEnv(routingPolicy)
 	ctxLogger := common.GetCtxLogger(ctx, identity, env)
-	defer util.LogElapsedTime("DeleteRoutingPolicy", identity, env, "-")
+	defer util.LogElapsedTime("DeleteRoutingPolicy", identity, env, "-")()
 	ctxLogger.Debugf(LogFormat, eventType, common.RoutingPolicyResourceType, routingPolicy.Name, "-", "start of delete for routing policy")
 	key := routingPolicy.Name + identity + env
 	if r.RemoteRegistry == nil || r.RemoteRegistry.AdmiralCache == nil || r.RemoteRegistry.AdmiralCache.RoutingPolicyFilterCache == nil {

--- a/admiral/pkg/clusters/routingpolicy_handler.go
+++ b/admiral/pkg/clusters/routingpolicy_handler.go
@@ -74,6 +74,15 @@ func (r *RoutingPolicyService) ProcessAddOrUpdate(ctx context.Context, eventType
 }
 
 func (r *RoutingPolicyService) ProcessDependency(ctx context.Context, eventType admiral.EventType, dependency *v1.Dependency) error {
+	if IsCacheWarmupTimeForDependency(r.RemoteRegistry) {
+		log.Debugf(LogFormat, string(eventType), common.DependencyResourceType, dependency.Name, "", "processing skipped during cache warm up state")
+		return nil
+	}
+
+	if !common.IsDependencyProcessingEnabled() {
+		log.Infof(LogFormat, string(eventType), common.DependencyResourceType, dependency.Name, "", "dependency processing is disabled")
+		return nil
+	}
 	newDestinations, _ := getDestinationsToBeProcessed(eventType, dependency, r.RemoteRegistry)
 	env := common.GetEnvFromMetadata(dependency.Annotations, dependency.Labels, nil)
 	ctxLogger := common.GetCtxLogger(ctx, dependency.Name, env)

--- a/admiral/pkg/clusters/routingpolicy_handler_test.go
+++ b/admiral/pkg/clusters/routingpolicy_handler_test.go
@@ -3,6 +3,7 @@ package clusters
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -24,6 +25,416 @@ import (
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const envoyFilterVersion_1_13 = "1.13"
+
+func TestNewRoutingPolicyProcessor(t *testing.T) {
+	common.ResetSync()
+	p := common.AdmiralParams{
+		KubeconfigPath: "testdata/fake.config",
+		LabelSet: &common.LabelSet{
+			DeploymentAnnotation: "sidecar.istio.io/inject",
+		},
+		EnableSAN:                  true,
+		SANPrefix:                  "prefix",
+		HostnameSuffix:             "mesh",
+		SyncNamespace:              "ns",
+		CacheReconcileDuration:     time.Minute,
+		ClusterRegistriesNamespace: "default",
+		DependenciesNamespace:      "default",
+		EnableRoutingPolicy:        true,
+		RoutingPolicyClusters:      []string{"*"},
+		EnvoyFilterVersion:         envoyFilterVersion_1_13,
+		Profile:                    common.AdmiralProfileDefault,
+	}
+
+	p.LabelSet.WorkloadIdentityKey = "identity"
+	p.LabelSet.EnvKey = "admiral.io/env"
+	p.LabelSet.AdmiralCRDIdentityLabel = "identity"
+
+	registry, _ := InitAdmiral(context.Background(), p)
+
+	rpFilterCache := &routingPolicyFilterCache{}
+	rpFilterCache.filterCache = make(map[string]map[string]map[string]string)
+	rpFilterCache.mutex = &sync.Mutex{}
+
+	routingPolicyController := &admiral.RoutingPolicyController{IstioClient: istiofake.NewSimpleClientset()}
+	bar1RCtrl, _ := createMockRemoteController(func(i interface{}) {})
+
+	bar1RCtrl.RoutingPolicyController = routingPolicyController
+	registry.remoteControllers = map[string]*RemoteController{"cluster-1": bar1RCtrl}
+	registry.AdmiralCache.RoutingPolicyFilterCache = rpFilterCache
+
+	registry.AdmiralCache.IdentityClusterCache.Put("bar", bar1RCtrl.ClusterID, bar1RCtrl.ClusterID)
+	registry.AdmiralCache.IdentityClusterCache.Put("bar2", "differentCluster", "differentCluster")
+
+	// foo is dependent upon bar and bar has a deployment in the same cluster.
+	registry.AdmiralCache.IdentityDependencyCache.Put("foo", "bar", "bar")
+
+	// foo2 is also dependent upon bar2 but bar2 is in a different(non-existent) cluster, so this cluster should not have the envoyfilter created
+	registry.AdmiralCache.IdentityDependencyCache.Put("foo2", "bar2", "bar2")
+
+	// foo1 is dependent upon bar 1 but bar1 does not have a deployment so it is missing from identityClusterCache
+	registry.AdmiralCache.IdentityDependencyCache.Put("foo1", "bar1", "bar1")
+
+	type args struct {
+		rr    *RemoteRegistry
+		et    admiral.EventType
+		newRP *admiralV1.RoutingPolicy
+		oldRP *admiralV1.RoutingPolicy
+		dp    map[string]string
+	}
+	type want struct {
+		err                               error
+		expectedFilterCacheKey            string
+		expectedFilterCount               int
+		expectedEnvoyFilterConfigPatchVal map[string]interface{}
+	}
+	update1FooRP := &admiralV1.RoutingPolicy{
+		TypeMeta: metaV1.TypeMeta{},
+		ObjectMeta: metaV1.ObjectMeta{
+			Name: "rpfoo",
+			Labels: map[string]string{
+				"identity":       "foo",
+				"admiral.io/env": "dev",
+			},
+		},
+		Spec: model.RoutingPolicy{
+			Plugin: "test",
+			Hosts:  []string{"e2e.testservice.mesh"},
+			Config: map[string]string{
+				"routingServiceUrl": "e2e.test.routing.service.mesh",
+			},
+		},
+		Status: admiralV1.RoutingPolicyStatus{},
+	}
+
+	update2FooRP := &admiralV1.RoutingPolicy{
+		TypeMeta: metaV1.TypeMeta{},
+		ObjectMeta: metaV1.ObjectMeta{
+			Name: "rpfoo",
+			Labels: map[string]string{
+				"identity":       "foo",
+				"admiral.io/env": "dev",
+			},
+		},
+		Spec: model.RoutingPolicy{
+			Plugin: "test",
+			Hosts:  []string{"e2e.testservice.mesh"},
+			Config: map[string]string{
+				"routingServiceUrl": "e2e.test.routing.service.mesh",
+				"prefix":            "updated",
+			},
+		},
+		Status: admiralV1.RoutingPolicyStatus{},
+	}
+
+	foo1RP := update1FooRP.DeepCopy()
+	foo1RP.Labels[common.GetWorkloadIdentifier()] = "foo1"
+
+	foo2RP := update1FooRP.DeepCopy()
+	foo1RP.Labels[common.GetWorkloadIdentifier()] = "foo2"
+
+	efnFooRp := envoyFilterName(update1FooRP, "bar")
+
+	testCases := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "New routing policy for an existing deployment of foo",
+			args: args{
+				rr:    registry,
+				et:    admiral.Add,
+				newRP: update1FooRP,
+				dp:    map[string]string{"bar": "bar"},
+			},
+			want: want{
+				expectedFilterCacheKey: "rpfoofoodev",
+				expectedFilterCount:    1,
+				expectedEnvoyFilterConfigPatchVal: map[string]interface{}{"name": "dynamicRoutingFilterPatch", "typed_config": map[string]interface{}{
+					"@type": "type.googleapis.com/udpa.type.v1.TypedStruct", "type_url": "type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm",
+					"value": map[string]interface{}{
+						"config": map[string]interface{}{
+							"configuration": map[string]interface{}{
+								"@type": "type.googleapis.com/google.protobuf.StringValue",
+								"value": "routingServiceUrl: e2e.test.routing.service.mesh\nhosts: e2e.testservice.mesh\nplugin: test"},
+							"vm_config": map[string]interface{}{"code": map[string]interface{}{"local": map[string]interface{}{"filename": ""}}, "runtime": "envoy.wasm.runtime.v8", "vm_id": efnFooRp}}}}},
+			},
+		},
+		{
+			name: "New routing policy but dependency cluster is missing",
+			args: args{
+				rr:    registry,
+				et:    admiral.Add,
+				newRP: foo1RP,
+				dp:    map[string]string{"bar1": "bar1"},
+			},
+			want: want{
+				expectedFilterCacheKey: "rpfoofoodev",
+				expectedFilterCount:    0,
+			},
+		},
+		{
+			name: "New routing policy and known cluster containing the deployment",
+			args: args{
+				rr:    registry,
+				et:    admiral.Add,
+				newRP: foo2RP,
+				dp:    map[string]string{"bar2": "bar2"},
+			},
+			want: want{
+				expectedFilterCacheKey: "rpfoofoodev",
+				expectedFilterCount:    0,
+			},
+		},
+		{
+			name: "Updated routing policy for an existing deployment of foo",
+			args: args{
+				rr:    registry,
+				et:    admiral.Add,
+				newRP: update2FooRP,
+				oldRP: update1FooRP,
+				dp:    map[string]string{"bar": "bar"},
+			},
+			want: want{
+				expectedFilterCacheKey: "rpfoofoodev",
+				expectedFilterCount:    1,
+				expectedEnvoyFilterConfigPatchVal: map[string]interface{}{"name": "dynamicRoutingFilterPatch", "typed_config": map[string]interface{}{
+					"@type": "type.googleapis.com/udpa.type.v1.TypedStruct", "type_url": "type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm",
+					"value": map[string]interface{}{
+						"config": map[string]interface{}{
+							"configuration": map[string]interface{}{
+								"@type": "type.googleapis.com/google.protobuf.StringValue",
+								"value": "routingServiceUrl: e2e.test.routing.service.mesh\nprefix: updated\nhosts: e2e.testservice.mesh\nplugin: test"},
+							"vm_config": map[string]interface{}{"code": map[string]interface{}{"local": map[string]interface{}{"filename": ""}}, "runtime": "envoy.wasm.runtime.v8", "vm_id": efnFooRp}}}}},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			// routing policy cache is empty
+			registry.AdmiralCache.RoutingPolicyCache = NewRoutingPolicyCache()
+			// routing policy cache is empty
+			if tc.args.oldRP != nil {
+				id := common.GetRoutingPolicyIdentity(tc.args.oldRP)
+				env := common.GetRoutingPolicyEnv(tc.args.oldRP)
+				name := tc.args.oldRP.Name
+				registry.AdmiralCache.RoutingPolicyCache.Put(id, env, name, tc.args.oldRP)
+			}
+			p := NewRoutingPolicyProcessor(tc.args.rr)
+			ae := p.ProcessAddOrUpdate(ctx, tc.args.et, tc.args.newRP, tc.args.oldRP, tc.args.dp)
+			if ae != nil && !errors.Is(ae, tc.want.err) {
+				t.Errorf("NewRoutingPolicyProcessor() = %v, want %v", ae, tc.want.err)
+				t.Fail()
+			}
+			list1, _ := bar1RCtrl.RoutingPolicyController.IstioClient.NetworkingV1alpha3().EnvoyFilters("istio-system").List(ctx, metaV1.ListOptions{})
+			assert.Equal(t, tc.want.expectedFilterCount, len(list1.Items))
+
+			if tc.want.expectedFilterCount > 0 {
+				receivedEnvoyFilter, _ := bar1RCtrl.RoutingPolicyController.IstioClient.NetworkingV1alpha3().EnvoyFilters("istio-system").Get(ctx, efnFooRp, metaV1.GetOptions{})
+				eq := reflect.DeepEqual(tc.want.expectedEnvoyFilterConfigPatchVal, receivedEnvoyFilter.Spec.ConfigPatches[0].Patch.Value.AsMap())
+				assert.True(t, eq)
+				assert.NotNil(t, registry.AdmiralCache.RoutingPolicyCache.Get("foo", "dev", "rpfoo"))
+			}
+
+			// once the routing policy is deleted, the corresponding filter should also be deleted
+			p.Delete(ctx, admiral.Delete, tc.args.newRP)
+			assert.Nil(t, registry.AdmiralCache.RoutingPolicyFilterCache.Get(tc.want.expectedFilterCacheKey))
+			assert.Nil(t, registry.AdmiralCache.RoutingPolicyCache.Get("foo", "dev", tc.args.newRP.Name))
+
+		})
+	}
+}
+
+func TestRoutingPolicyProcess_DependencyUpdate_AddOrUpdate(t *testing.T) {
+	common.ResetSync()
+	p := common.AdmiralParams{
+		KubeconfigPath: "testdata/fake.config",
+		LabelSet: &common.LabelSet{
+			DeploymentAnnotation: "sidecar.istio.io/inject",
+		},
+		EnableSAN:                  true,
+		SANPrefix:                  "prefix",
+		HostnameSuffix:             "mesh",
+		SyncNamespace:              "ns",
+		CacheReconcileDuration:     time.Minute,
+		ClusterRegistriesNamespace: "default",
+		DependenciesNamespace:      "default",
+		EnableRoutingPolicy:        true,
+		RoutingPolicyClusters:      []string{"cluster-1"},
+		EnvoyFilterVersion:         envoyFilterVersion_1_13,
+		Profile:                    common.AdmiralProfileDefault,
+	}
+
+	p.LabelSet.WorkloadIdentityKey = "identity"
+	p.LabelSet.EnvKey = "admiral.io/env"
+	p.LabelSet.AdmiralCRDIdentityLabel = "identity"
+
+	registry, _ := InitAdmiral(context.Background(), p)
+	registry.AdmiralCache.SourceToDestinations = &sourceToDestinations{
+		sourceDestinations: map[string][]string{
+			"foo": {"bar"},
+		},
+		mutex: &sync.Mutex{},
+	}
+
+	routingPolicyController := &admiral.RoutingPolicyController{IstioClient: istiofake.NewSimpleClientset()}
+	allowedCluster, _ := createMockRemoteController(func(i interface{}) {})
+	allowedCluster.ClusterID = "cluster-1"
+
+	disabledCluster, _ := createMockRemoteController(func(i interface{}) {})
+	disabledCluster.ClusterID = "cluster-2"
+
+	rpFilterCache := &routingPolicyFilterCache{}
+	rpFilterCache.filterCache = make(map[string]map[string]map[string]string)
+	rpFilterCache.mutex = &sync.Mutex{}
+
+	allowedCluster.RoutingPolicyController = routingPolicyController
+	registry.remoteControllers = map[string]*RemoteController{"cluster-1": allowedCluster, "cluster-2": disabledCluster}
+	registry.AdmiralCache.RoutingPolicyFilterCache = rpFilterCache
+
+	registry.AdmiralCache.IdentityDependencyCache.Put("foo", "bar", "bar")
+	registry.AdmiralCache.IdentityClusterCache.Put("bar", allowedCluster.ClusterID, allowedCluster.ClusterID)
+	registry.AdmiralCache.IdentityClusterCache.Put("bar2", allowedCluster.ClusterID, allowedCluster.ClusterID)
+	registry.AdmiralCache.IdentityClusterCache.Put("baz", disabledCluster.ClusterID, disabledCluster.ClusterID)
+
+	fooRP := &admiralV1.RoutingPolicy{
+		TypeMeta: metaV1.TypeMeta{},
+		ObjectMeta: metaV1.ObjectMeta{
+			Name: "rpfoo",
+			Labels: map[string]string{
+				"identity":       "foo",
+				"admiral.io/env": "dev",
+			},
+		},
+		Spec: model.RoutingPolicy{
+			Plugin: "test",
+			Hosts:  []string{"e2e.testservice.mesh"},
+			Config: map[string]string{
+				"routingServiceUrl": "e2e.test.routing.service.mesh",
+			},
+		},
+		Status: admiralV1.RoutingPolicyStatus{},
+	}
+	registry.AdmiralCache.RoutingPolicyCache.Put("foo", "dev", "foo", fooRP)
+
+	type args struct {
+		rr         *RemoteRegistry
+		dependency *admiralV1.Dependency
+	}
+	type want struct {
+		err                                         error
+		expectedFilterCacheKey                      string
+		filterCountInCluster1                       int
+		filterCountInCluster2                       int
+		expectedEnvoyFilterConfigPatchValInCluster1 map[string]interface{}
+	}
+
+	efn := envoyFilterName(fooRP, "bar2")
+
+	testCases := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "Adding a new destination to dependency in an enabled cluster adds the filter",
+			args: args{
+				rr: registry,
+				dependency: &admiralV1.Dependency{
+					TypeMeta: metaV1.TypeMeta{},
+					ObjectMeta: metaV1.ObjectMeta{
+						Name: "foo-dep",
+						Labels: map[string]string{
+							"identity":       "bar2",
+							"admiral.io/env": "dev",
+						},
+					},
+					Spec: model.Dependency{
+						Source:        "bar2",
+						IdentityLabel: "identity",
+						Destinations:  []string{"foo"},
+					},
+				},
+			},
+			want: want{
+				filterCountInCluster1:  1,
+				expectedFilterCacheKey: "rpfoofoodev",
+				expectedEnvoyFilterConfigPatchValInCluster1: map[string]interface{}{"name": "dynamicRoutingFilterPatch", "typed_config": map[string]interface{}{
+					"@type": "type.googleapis.com/udpa.type.v1.TypedStruct", "type_url": "type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm",
+					"value": map[string]interface{}{
+						"config": map[string]interface{}{
+							"configuration": map[string]interface{}{
+								"@type": "type.googleapis.com/google.protobuf.StringValue",
+								"value": "routingServiceUrl: e2e.test.routing.service.mesh\nhosts: e2e.testservice.mesh\nplugin: test"},
+							"vm_config": map[string]interface{}{"code": map[string]interface{}{"local": map[string]interface{}{"filename": ""}}, "runtime": "envoy.wasm.runtime.v8", "vm_id": efn}}}}},
+			},
+		},
+		{
+			name: "Adding a new destination to dependency in a disabled cluster does nothing",
+			args: args{
+				rr: registry,
+				dependency: &admiralV1.Dependency{
+					TypeMeta: metaV1.TypeMeta{},
+					ObjectMeta: metaV1.ObjectMeta{
+						Name: "foo-dep",
+						Labels: map[string]string{
+							"identity":       "baz",
+							"admiral.io/env": "dev",
+						},
+					},
+					Spec: model.Dependency{
+						Source:        "baz",
+						IdentityLabel: "identity",
+						Destinations:  []string{"foo"},
+					},
+				},
+			},
+			want: want{},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			processor := NewRoutingPolicyProcessor(tc.args.rr)
+			err := processor.ProcessDependency(ctx, admiral.Update, tc.args.dependency)
+			if err != nil && tc.want.err == nil {
+				t.Errorf("ProcessDependency() unexpected error = %v", err)
+			}
+
+			// cluster 1
+			list1, _ := allowedCluster.RoutingPolicyController.IstioClient.NetworkingV1alpha3().EnvoyFilters("istio-system").List(ctx, metaV1.ListOptions{})
+			assert.Equal(t, tc.want.filterCountInCluster1, len(list1.Items))
+			if tc.want.filterCountInCluster1 > 0 {
+
+				receivedEnvoyFilter, _ := allowedCluster.RoutingPolicyController.IstioClient.NetworkingV1alpha3().EnvoyFilters("istio-system").Get(ctx, efn, metaV1.GetOptions{})
+				eq := reflect.DeepEqual(tc.want.expectedEnvoyFilterConfigPatchValInCluster1, receivedEnvoyFilter.Spec.ConfigPatches[0].Patch.Value.AsMap())
+				assert.True(t, eq)
+				assert.NotNil(t, registry.AdmiralCache.RoutingPolicyCache.Get("foo", "dev", "rpfoo"))
+
+				// cleanup
+				processor.Delete(ctx, admiral.Delete, fooRP)
+				assert.Nil(t, registry.AdmiralCache.RoutingPolicyFilterCache.Get(tc.want.expectedFilterCacheKey))
+				assert.Nil(t, registry.AdmiralCache.RoutingPolicyCache.Get("foo", "dev", fooRP.Name))
+			}
+
+			// cluster 2
+			list2, _ := disabledCluster.RoutingPolicyController.IstioClient.NetworkingV1alpha3().EnvoyFilters("istio-system").List(ctx, metaV1.ListOptions{})
+			assert.Equal(t, tc.want.filterCountInCluster2, len(list2.Items))
+		})
+	}
+}
+
+func envoyFilterName(fooRP *admiralV1.RoutingPolicy, dependentIdentity string) string {
+	name, _ := common.GetSha1(fooRP.Name + common.GetRoutingPolicyEnv(fooRP) + common.GetRoutingPolicyIdentity(fooRP))
+	dependentIdentitySha, _ := common.GetSha1(dependentIdentity)
+	envoyFilterName := fmt.Sprintf("%s-dr-%s-%s-%s", strings.ToLower(fooRP.Spec.Plugin), name, dependentIdentitySha, envoyFilterVersion_1_13)
+	return envoyFilterName
+}
+
 func TestRoutingPolicyHandler(t *testing.T) {
 	common.ResetSync()
 	p := common.AdmiralParams{
@@ -40,7 +451,7 @@ func TestRoutingPolicyHandler(t *testing.T) {
 		DependenciesNamespace:      "default",
 		EnableRoutingPolicy:        true,
 		RoutingPolicyClusters:      []string{"*"},
-		EnvoyFilterVersion:         "1.13",
+		EnvoyFilterVersion:         envoyFilterVersion_1_13,
 		Profile:                    common.AdmiralProfileDefault,
 	}
 
@@ -50,19 +461,14 @@ func TestRoutingPolicyHandler(t *testing.T) {
 
 	registry, _ := InitAdmiral(context.Background(), p)
 
-	handler := RoutingPolicyHandler{}
-
 	rpFilterCache := &routingPolicyFilterCache{}
 	rpFilterCache.filterCache = make(map[string]map[string]map[string]string)
 	rpFilterCache.mutex = &sync.Mutex{}
 
 	routingPolicyController := &admiral.RoutingPolicyController{IstioClient: istiofake.NewSimpleClientset()}
-	remoteController, _ := createMockRemoteController(func(i interface{}) {
-
-	})
+	remoteController, _ := createMockRemoteController(func(i interface{}) {})
 
 	remoteController.RoutingPolicyController = routingPolicyController
-
 	registry.remoteControllers = map[string]*RemoteController{"cluster-1": remoteController}
 	registry.AdmiralCache.RoutingPolicyFilterCache = rpFilterCache
 
@@ -70,38 +476,16 @@ func TestRoutingPolicyHandler(t *testing.T) {
 	registry.AdmiralCache.IdentityDependencyCache.Put("foo", "bar", "bar")
 	registry.AdmiralCache.IdentityClusterCache.Put("bar", remoteController.ClusterID, remoteController.ClusterID)
 
-	// foo is also dependent upon bar2 but bar2 is in a different cluster, so this cluster should not have the envoyfilter created
+	// foo2 is also dependent upon bar2 but bar2 is in a different cluster, so this cluster should not have the envoyfilter created
 	registry.AdmiralCache.IdentityDependencyCache.Put("foo2", "bar2", "bar2")
 	registry.AdmiralCache.IdentityClusterCache.Put("bar2", "differentCluster", "differentCluster")
 
 	// foo1 is dependent upon bar 1 but bar1 does not have a deployment so it is missing from identityClusterCache
 	registry.AdmiralCache.IdentityDependencyCache.Put("foo1", "bar1", "bar1")
-
-	handler.RemoteRegistry = registry
-
-	routingPolicyFoo := &admiralV1.RoutingPolicy{
-		TypeMeta: metaV1.TypeMeta{},
-		ObjectMeta: metaV1.ObjectMeta{
-			Name: "rpfoo",
-			Labels: map[string]string{
-				"identity":       "foo",
-				"admiral.io/env": "dev",
-			},
-		},
-		Spec: model.RoutingPolicy{
-			Plugin: "test",
-			Hosts:  []string{"e2e.testservice.mesh"},
-			Config: map[string]string{
-				"cachePrefix":       "cache-v1",
-				"cachettlSec":       "86400",
-				"routingServiceUrl": "e2e.test.routing.service.mesh",
-				"pathPrefix":        "/sayhello,/v1/company/{id}/",
-			},
-		},
-		Status: admiralV1.RoutingPolicyStatus{},
-	}
-
-	routingPolicyFooTest := &admiralV1.RoutingPolicy{
+	processor := &MockPolicyProcessor{}
+	oops := errors.New("oops")
+	errProcessor := &MockPolicyProcessor{err: oops}
+	fooRP := &admiralV1.RoutingPolicy{
 		TypeMeta: metaV1.TypeMeta{},
 		ObjectMeta: metaV1.ObjectMeta{
 			Name: "rpfoo",
@@ -119,95 +503,127 @@ func TestRoutingPolicyHandler(t *testing.T) {
 		},
 		Status: admiralV1.RoutingPolicyStatus{},
 	}
-
-	routingPolicyFoo1 := routingPolicyFoo.DeepCopy()
-	routingPolicyFoo1.Labels[common.GetWorkloadIdentifier()] = "foo1"
-
-	routingPolicyFoo2 := routingPolicyFoo.DeepCopy()
-	routingPolicyFoo2.Labels[common.GetWorkloadIdentifier()] = "foo2"
-
+	type args struct {
+		proc      *MockPolicyProcessor
+		eventType admiral.EventType
+		rp        *admiralV1.RoutingPolicy
+	}
+	type want struct {
+		err         error
+		addCount    int
+		delCount    int
+		updateCount int
+	}
+	time.Sleep(time.Second * 10)
 	testCases := []struct {
-		name                              string
-		routingPolicy                     *admiralV1.RoutingPolicy
-		expectedFilterCacheKey            string
-		expectedFilterCount               int
-		expectedEnvoyFilterConfigPatchVal map[string]interface{}
+		name string
+		args args
+		want want
 	}{
 		{
-			name:                   "If dependent deployment exists, should fetch filter from cache",
-			routingPolicy:          routingPolicyFooTest,
-			expectedFilterCacheKey: "rpfoofoodev",
-			expectedFilterCount:    1,
-			expectedEnvoyFilterConfigPatchVal: map[string]interface{}{"name": "dynamicRoutingFilterPatch", "typed_config": map[string]interface{}{
-				"@type": "type.googleapis.com/udpa.type.v1.TypedStruct", "type_url": "type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm",
-				"value": map[string]interface{}{
-					"config": map[string]interface{}{
-						"configuration": map[string]interface{}{
-							"@type": "type.googleapis.com/google.protobuf.StringValue",
-							"value": "routingServiceUrl: e2e.test.routing.service.mesh\nhosts: e2e.testservice.mesh\nplugin: test"},
-						"vm_config": map[string]interface{}{"code": map[string]interface{}{"local": map[string]interface{}{"filename": ""}}, "runtime": "envoy.wasm.runtime.v8", "vm_id": "test-dr-532221909d5db54fe5f5-f6ce3712830af1b15625-1.13"}}}}},
+			name: "Add event is propagated correctly",
+			args: args{
+				proc:      processor,
+				eventType: admiral.Add,
+				rp:        fooRP,
+			},
+			want: want{
+				addCount: 1,
+			},
 		},
 		{
-			name:                   "If dependent deployment does not exist, the filter should not be created ",
-			routingPolicy:          routingPolicyFoo1,
-			expectedFilterCacheKey: "rpfoofoodev",
-			expectedFilterCount:    0,
+			name: "Err on Add event",
+			args: args{
+				proc:      errProcessor,
+				eventType: admiral.Add,
+				rp:        fooRP,
+			},
+			want: want{
+				err: oops,
+			},
 		},
 		{
-			name:                   "If dependent deployment exists in a different cluster, the filter should not be created in cluster where dependency isnt there",
-			routingPolicy:          routingPolicyFoo2,
-			expectedFilterCacheKey: "rpfoofoodev",
-			expectedFilterCount:    0,
+			name: "Update event is propagated correctly",
+			args: args{
+				proc:      processor,
+				eventType: admiral.Update,
+				rp:        fooRP,
+			},
+			want: want{
+				updateCount: 1,
+			},
+		},
+		{
+			name: "Err on update event",
+			args: args{
+				proc:      errProcessor,
+				eventType: admiral.Update,
+				rp:        fooRP,
+			},
+			want: want{
+				err: oops,
+			},
+		},
+		{
+			name: "Delete event is propagated correctly",
+			args: args{
+				proc:      processor,
+				eventType: admiral.Delete,
+				rp:        fooRP,
+			},
+			want: want{
+				delCount: 1,
+			},
+		},
+		{
+			name: "Err on delete event",
+			args: args{
+				proc:      errProcessor,
+				eventType: admiral.Delete,
+				rp:        fooRP,
+			},
+			want: want{
+				err: oops,
+			},
 		},
 	}
 
 	ctx := context.Background()
 
-	time.Sleep(time.Second * 30)
 	for _, c := range testCases {
 		t.Run(c.name, func(t *testing.T) {
-			handler.Added(ctx, c.routingPolicy)
-			if c.expectedFilterCount > 0 {
-				filterCacheValue := registry.AdmiralCache.RoutingPolicyFilterCache.Get(c.expectedFilterCacheKey)
-				assert.NotNil(t, filterCacheValue)
-				routingPolicyNameSha, _ := getSha1(c.routingPolicy.Name + common.GetRoutingPolicyEnv(c.routingPolicy) + common.GetRoutingPolicyIdentity(c.routingPolicy))
-				dependentIdentitySha, _ := getSha1("bar")
-				envoyFilterName := fmt.Sprintf("%s-dr-%s-%s-%s", strings.ToLower(c.routingPolicy.Spec.Plugin), routingPolicyNameSha, dependentIdentitySha, "1.13")
-
-				filterMap := filterCacheValue[remoteController.ClusterID]
-				assert.NotNil(t, filterMap)
-				assert.NotNil(t, filterMap[envoyFilterName])
-
-				filter, err := remoteController.RoutingPolicyController.IstioClient.NetworkingV1alpha3().
-					EnvoyFilters("istio-system").Get(ctx, envoyFilterName, metaV1.GetOptions{})
-				assert.Nil(t, err)
-				assert.NotNil(t, filter)
+			handler := NewRoutingPolicyHandler(registry, "", c.args.proc)
+			switch c.args.eventType {
+			case admiral.Add:
+				err := handler.Added(ctx, c.args.rp)
+				if c.want.err != nil && !errors.Is(err, c.want.err) {
+					t.Errorf("RoutingPolicyHandler.Added() = %v, want %v", err, c.want.err)
+					t.Fail()
+				}
+				if c.want.addCount > 0 {
+					assert.Equal(t, c.args.proc.addCount, c.want.addCount)
+				}
+			case admiral.Update:
+				err := handler.Updated(ctx, c.args.rp, nil)
+				if c.want.err != nil && !errors.Is(err, c.want.err) {
+					t.Errorf("RoutingPolicyHandler.Updated() = %v, want %v", err, c.want.err)
+					t.Fail()
+				}
+				if c.want.addCount > 0 {
+					assert.Equal(t, c.args.proc.addCount, c.want.addCount)
+				}
+			case admiral.Delete:
+				err := handler.Deleted(ctx, c.args.rp)
+				if c.want.err != nil && !errors.Is(err, c.want.err) {
+					t.Errorf("RoutingPolicyHandler.Deleted() = %v, want %v", err, c.want.err)
+					t.Fail()
+				}
+				if c.want.addCount > 0 {
+					assert.Equal(t, c.args.proc.addCount, c.want.addCount)
+				}
 			}
-			//get envoyfilters from all namespaces
-			list1, _ := remoteController.RoutingPolicyController.IstioClient.NetworkingV1alpha3().EnvoyFilters("istio-system").List(ctx, metaV1.ListOptions{})
-			assert.Equal(t, c.expectedFilterCount, len(list1.Items))
-			if c.expectedFilterCount > 0 {
-				receivedEnvoyFilter, _ := remoteController.RoutingPolicyController.IstioClient.NetworkingV1alpha3().EnvoyFilters("istio-system").Get(ctx, "test-dr-532221909d5db54fe5f5-f6ce3712830af1b15625-1.13", metaV1.GetOptions{})
-				eq := reflect.DeepEqual(c.expectedEnvoyFilterConfigPatchVal, receivedEnvoyFilter.Spec.ConfigPatches[0].Patch.Value.AsMap())
-				assert.True(t, eq)
-			}
-
-			// once the routing policy is deleted, the corresponding filter should also be deleted
-			handler.Deleted(ctx, c.routingPolicy)
-			assert.Nil(t, registry.AdmiralCache.RoutingPolicyFilterCache.Get(c.expectedFilterCacheKey))
 		})
 	}
-
-	// ignore the routing policy
-	annotations := routingPolicyFoo.GetAnnotations()
-	if annotations == nil {
-		annotations = make(map[string]string)
-	}
-	annotations[common.AdmiralIgnoreAnnotation] = "true"
-	routingPolicyFoo.SetAnnotations(annotations)
-
-	handler.Updated(ctx, routingPolicyFoo)
-	assert.Nil(t, registry.AdmiralCache.RoutingPolicyFilterCache.Get("rpfoofoodev"))
 }
 
 func TestRoutingPolicyReadOnly(t *testing.T) {
@@ -223,14 +639,14 @@ func TestRoutingPolicyReadOnly(t *testing.T) {
 		DependenciesNamespace:      "default",
 		EnableRoutingPolicy:        true,
 		RoutingPolicyClusters:      []string{"*"},
-		EnvoyFilterVersion:         "1.13",
+		EnvoyFilterVersion:         envoyFilterVersion_1_13,
 	}
 
 	p.LabelSet.WorkloadIdentityKey = "identity"
 	p.LabelSet.EnvKey = "admiral.io/env"
 	p.LabelSet.AdmiralCRDIdentityLabel = "identity"
 
-	handler := RoutingPolicyHandler{}
+	handler := NewRoutingPolicyHandler(nil, "", NewRoutingPolicyProcessor(nil))
 
 	testcases := []struct {
 		name      string
@@ -273,7 +689,7 @@ func TestRoutingPolicyReadOnly(t *testing.T) {
 			assert.Equal(t, c.doesError, val)
 
 			// Update routing policy test
-			handler.Updated(ctx, c.rp)
+			handler.Updated(ctx, c.rp, nil)
 			t.Log(buf.String())
 			val = strings.Contains(buf.String(), "skipping read-only mode")
 			assert.Equal(t, c.doesError, val)
@@ -287,7 +703,7 @@ func TestRoutingPolicyReadOnly(t *testing.T) {
 	}
 }
 
-func TestRoutingPolicyDisabled_ForEmptyClusters(t *testing.T) {
+func TestRoutingPolicyIgnored(t *testing.T) {
 	common.ResetSync()
 	p := common.AdmiralParams{
 		KubeconfigPath: "testdata/fake.config",
@@ -302,8 +718,89 @@ func TestRoutingPolicyDisabled_ForEmptyClusters(t *testing.T) {
 		ClusterRegistriesNamespace: "default",
 		DependenciesNamespace:      "default",
 		EnableRoutingPolicy:        true,
-		RoutingPolicyClusters:      []string{},
-		EnvoyFilterVersion:         "1.13",
+		RoutingPolicyClusters:      []string{"*"},
+		EnvoyFilterVersion:         envoyFilterVersion_1_13,
+		Profile:                    common.AdmiralProfileDefault,
+	}
+
+	p.LabelSet.WorkloadIdentityKey = "identity"
+	p.LabelSet.EnvKey = "admiral.io/env"
+	p.LabelSet.AdmiralCRDIdentityLabel = "identity"
+
+	registry, _ := InitAdmiral(context.Background(), p)
+	processor := &MockPolicyProcessor{}
+	handler := NewRoutingPolicyHandler(registry, "", processor)
+
+	type want struct {
+		err         error
+		addCount    int
+		delCount    int
+		updateCount int
+	}
+	testcases := []struct {
+		name string
+		rp   *admiralV1.RoutingPolicy
+		want want
+	}{
+		{
+			name: "Ignore Routing Policy - Annotation",
+			rp: &admiralV1.RoutingPolicy{
+				ObjectMeta: metaV1.ObjectMeta{
+					Annotations: map[string]string{
+						"admiral.io/ignore": "true",
+					},
+				},
+			},
+			want: want{},
+		},
+		{
+			name: "Ignore Routing Policy - Label",
+			rp: &admiralV1.RoutingPolicy{
+				ObjectMeta: metaV1.ObjectMeta{
+					Labels: map[string]string{
+						"admiral.io/ignore": "true",
+					},
+				},
+			},
+			want: want{},
+		},
+	}
+
+	ctx := context.Background()
+
+	for _, c := range testcases {
+		t.Run(c.name, func(t *testing.T) {
+			handler.Added(ctx, c.rp)
+			assert.Equal(t, c.want.addCount, 0)
+
+			// Update routing policy test
+			handler.Updated(ctx, c.rp, nil)
+			assert.Equal(t, c.want.updateCount, 0)
+
+			// Delete routing policy test
+			handler.Deleted(ctx, c.rp)
+			assert.Equal(t, c.want.delCount, 0)
+		})
+	}
+}
+
+func TestRoutingPolicyProcessingDisabled(t *testing.T) {
+	common.ResetSync()
+	p := common.AdmiralParams{
+		KubeconfigPath: "testdata/fake.config",
+		LabelSet: &common.LabelSet{
+			DeploymentAnnotation: "sidecar.istio.io/inject",
+		},
+		EnableSAN:                  true,
+		SANPrefix:                  "prefix",
+		HostnameSuffix:             "mesh",
+		SyncNamespace:              "ns",
+		CacheReconcileDuration:     time.Minute,
+		ClusterRegistriesNamespace: "default",
+		DependenciesNamespace:      "default",
+		EnableRoutingPolicy:        false,
+		RoutingPolicyClusters:      []string{"*"},
+		EnvoyFilterVersion:         envoyFilterVersion_1_13,
 		Profile:                    common.AdmiralProfileDefault,
 	}
 
@@ -313,55 +810,165 @@ func TestRoutingPolicyDisabled_ForEmptyClusters(t *testing.T) {
 
 	registry, _ := InitAdmiral(context.Background(), p)
 
-	handler := RoutingPolicyHandler{}
+	processor := &MockPolicyProcessor{}
+	handler := NewRoutingPolicyHandler(registry, "", processor)
 
-	rpFilterCache := &routingPolicyFilterCache{}
-	rpFilterCache.filterCache = make(map[string]map[string]map[string]string)
-	rpFilterCache.mutex = &sync.Mutex{}
-
-	routingPolicyController := &admiral.RoutingPolicyController{IstioClient: istiofake.NewSimpleClientset()}
-	remoteController, _ := createMockRemoteController(func(i interface{}) {
-
-	})
-
-	remoteController.RoutingPolicyController = routingPolicyController
-
-	registry.remoteControllers = map[string]*RemoteController{"cluster-1": remoteController}
-	registry.AdmiralCache.RoutingPolicyFilterCache = rpFilterCache
-
-	// foo is dependent upon bar and bar has a deployment in the same cluster.
-	registry.AdmiralCache.IdentityDependencyCache.Put("foo", "bar", "bar")
-	registry.AdmiralCache.IdentityClusterCache.Put("bar", remoteController.ClusterID, remoteController.ClusterID)
-
-	handler.RemoteRegistry = registry
-	routingPolicy := &admiralV1.RoutingPolicy{
-		TypeMeta: metaV1.TypeMeta{},
-		ObjectMeta: metaV1.ObjectMeta{
-			Name: "rpfoo",
-			Labels: map[string]string{
-				"identity":       "foo",
-				"admiral.io/env": "dev",
-			},
-		},
-		Spec: model.RoutingPolicy{
-			Plugin: "test",
-			Hosts:  []string{"e2e.testservice.mesh"},
-			Config: map[string]string{
-				"cachePrefix":       "cache-v1",
-				"cachettlSec":       "86400",
-				"routingServiceUrl": "e2e.test.routing.service.mesh",
-				"pathPrefix":        "/sayhello,/v1/company/{id}/",
-			},
-		},
-		Status: admiralV1.RoutingPolicyStatus{},
+	type want struct {
+		err         error
+		addCount    int
+		delCount    int
+		updateCount int
 	}
+	testcases := []struct {
+		name string
+		rp   *admiralV1.RoutingPolicy
+		want want
+	}{
+		{
+			name: "Disabled",
+			rp: &admiralV1.RoutingPolicy{
+				ObjectMeta: metaV1.ObjectMeta{
+					Annotations: map[string]string{
+						"admiral.io/ignore": "true",
+					},
+				},
+			},
+			want: want{},
+		},
+	}
+
 	ctx := context.Background()
 
-	handler.Added(ctx, routingPolicy)
-	// No-Op. Filters should not be created
-	assert.Nil(t, registry.AdmiralCache.RoutingPolicyFilterCache.Get("rpfoofoodev"))
+	for _, c := range testcases {
+		t.Run(c.name, func(t *testing.T) {
+			handler.Added(ctx, c.rp)
+			assert.Equal(t, c.want.addCount, 0)
 
-	handler.Deleted(ctx, routingPolicy)
-	// No-Op. Should not panic or throw errors
-	assert.Nil(t, registry.AdmiralCache.RoutingPolicyFilterCache.Get("rpfoofoodev"))
+			// Update routing policy test
+			handler.Updated(ctx, c.rp, nil)
+			assert.Equal(t, c.want.updateCount, 0)
+
+			// Delete routing policy test
+			handler.Deleted(ctx, c.rp)
+			assert.Equal(t, c.want.delCount, 0)
+		})
+	}
+}
+
+func TestRoutingPolicyCache_Put(t *testing.T) {
+	rp := NewRoutingPolicyCache()
+
+	rp.Put("foo", "dev", "rpfoo", nil)
+	assert.Nil(t, rp.Get("foo", "dev", "rpfoo"))
+
+	rp.Put("foo", "dev", "rpfoo", &admiralV1.RoutingPolicy{})
+	assert.NotNil(t, rp.Get("foo", "dev", "rpfoo"))
+}
+
+func TestRoutingPolicyCache_Delete(t *testing.T) {
+	p := common.AdmiralParams{
+		KubeconfigPath: "testdata/fake.config",
+		LabelSet: &common.LabelSet{
+			DeploymentAnnotation: "sidecar.istio.io/inject",
+		},
+		EnableSAN:                  true,
+		SANPrefix:                  "prefix",
+		HostnameSuffix:             "mesh",
+		SyncNamespace:              "ns",
+		CacheReconcileDuration:     time.Minute,
+		ClusterRegistriesNamespace: "default",
+		DependenciesNamespace:      "default",
+		EnvoyFilterVersion:         envoyFilterVersion_1_13,
+		Profile:                    common.AdmiralProfileDefault,
+	}
+
+	p.LabelSet.WorkloadIdentityKey = "identity"
+	p.LabelSet.EnvKey = "admiral.io/env"
+	p.LabelSet.AdmiralCRDIdentityLabel = "identity"
+
+	type args struct {
+		readOnly            bool
+		enableRoutingPolicy bool
+		identity            string
+		env                 string
+		name                string
+	}
+	testCases := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "Admiral should delete from cache",
+			args: args{
+				readOnly:            false,
+				enableRoutingPolicy: true,
+				identity:            "foo",
+				env:                 "dev",
+				name:                "rpfoo",
+			},
+		},
+		{
+			name: "Admiral should not delete from cache during readOnly",
+			args: args{
+				readOnly:            true,
+				enableRoutingPolicy: true,
+				identity:            "foo",
+				env:                 "dev",
+				name:                "rpfoo",
+			},
+		},
+		{
+			name: "Admiral should not delete from cache when disabled",
+			args: args{
+				readOnly:            false,
+				enableRoutingPolicy: false,
+				identity:            "foo",
+				env:                 "dev",
+				name:                "rpfoo",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			common.ResetSync()
+			p.EnableRoutingPolicy = tc.args.enableRoutingPolicy
+			InitAdmiral(context.Background(), p)
+			commonUtil.CurrentAdmiralState.ReadOnly = tc.args.readOnly
+			cache := NewRoutingPolicyCache()
+			rp := &admiralV1.RoutingPolicy{}
+			cache.Put(tc.args.identity, tc.args.env, tc.args.name, rp)
+			cache.Delete(tc.args.identity, tc.args.env, tc.args.name)
+			if tc.args.readOnly {
+				assert.NotNil(t, cache.Get(tc.args.identity, tc.args.env, tc.args.name))
+			} else {
+				if tc.args.enableRoutingPolicy {
+					assert.Nil(t, cache.Get(tc.args.identity, tc.args.env, tc.args.name))
+				} else {
+					assert.NotNil(t, cache.Get(tc.args.identity, tc.args.env, tc.args.name))
+				}
+			}
+		})
+	}
+}
+
+type MockPolicyProcessor struct {
+	addCount    int
+	depCount    int
+	deleteCount int
+	err         error
+}
+
+func (m *MockPolicyProcessor) ProcessAddOrUpdate(ctx context.Context, eventType admiral.EventType, newRP *admiralV1.RoutingPolicy, oldRP *admiralV1.RoutingPolicy, dependents map[string]string) error {
+	m.addCount++
+	return m.err
+}
+
+func (m *MockPolicyProcessor) ProcessDependency(ctx context.Context, eventType admiral.EventType, dependency *admiralV1.Dependency) error {
+	m.depCount++
+	return m.err
+}
+
+func (m *MockPolicyProcessor) Delete(ctx context.Context, eventType admiral.EventType, routingPolicy *admiralV1.RoutingPolicy) error {
+	m.deleteCount++
+	return m.err
 }

--- a/admiral/pkg/clusters/routingpolicy_handler_test.go
+++ b/admiral/pkg/clusters/routingpolicy_handler_test.go
@@ -710,63 +710,6 @@ func TestRoutingPolicyHandler(t *testing.T) {
 	}
 }
 
-func TestRoutingPolicyReadOnly(t *testing.T) {
-	common.ResetSync()
-	p := common.AdmiralParams{
-		KubeconfigPath:             "testdata/fake.config",
-		LabelSet:                   &common.LabelSet{},
-		EnableSAN:                  true,
-		SANPrefix:                  "prefix",
-		HostnameSuffix:             "mesh",
-		SyncNamespace:              "ns",
-		ClusterRegistriesNamespace: "default",
-		DependenciesNamespace:      "default",
-		EnableRoutingPolicy:        true,
-		RoutingPolicyClusters:      []string{"*"},
-		EnvoyFilterVersion:         envoyFilterVersion_1_13,
-		EnableDependencyProcessing: false,
-	}
-
-	p.LabelSet.WorkloadIdentityKey = "identity"
-	p.LabelSet.EnvKey = "admiral.io/env"
-	p.LabelSet.AdmiralCRDIdentityLabel = "identity"
-
-	registry, _ := InitAdmiral(context.Background(), p)
-	registry.AdmiralCache.RoutingPolicyCache = NewRoutingPolicyCache()
-
-	handler := NewRoutingPolicyHandler(registry, "", NewRoutingPolicyProcessor(registry))
-
-	testcases := []struct {
-		name      string
-		rp        *admiralV1.RoutingPolicy
-		readOnly  bool
-		doesError bool
-	}{
-		{
-			name: "Readonly test - Routing Policy",
-			rp:   &admiralV1.RoutingPolicy{},
-		},
-	}
-
-	ctx := context.Background()
-
-	for _, c := range testcases {
-		t.Run(c.name, func(t *testing.T) {
-			commonUtil.CurrentAdmiralState.ReadOnly = true
-
-			// Add routing policy test
-			err := handler.Added(ctx, c.rp)
-			assert.Nil(t, err)
-			assert.NoError(t, err)
-
-			// Update routing policy test
-			err = handler.Updated(ctx, c.rp, nil)
-			assert.Nil(t, err)
-			assert.NoError(t, err)
-		})
-	}
-}
-
 func TestRoutingPolicyIgnored(t *testing.T) {
 	common.ResetSync()
 	p := common.AdmiralParams{

--- a/admiral/pkg/clusters/types.go
+++ b/admiral/pkg/clusters/types.go
@@ -69,6 +69,7 @@ type AdmiralCache struct {
 	DependencyNamespaceCache            *common.SidecarEgressMap
 	SeClusterCache                      *common.MapOfMaps
 	RoutingPolicyFilterCache            *routingPolicyFilterCache
+	RoutingPolicyCache                  *RoutingPolicyCache
 	SourceToDestinations                *sourceToDestinations //This cache is to fetch list of all dependencies for a given source identity,
 	TrafficConfigIgnoreAssets           []string
 	GatewayAssets                       []string
@@ -133,6 +134,7 @@ func NewRemoteRegistry(ctx context.Context, params common.AdmiralParams) *Remote
 		CnameDependentClusterCache:  common.NewMapOfMaps(),
 		IdentityDependencyCache:     common.NewMapOfMaps(),
 		RoutingPolicyFilterCache:    rpFilterCache,
+		RoutingPolicyCache:          NewRoutingPolicyCache(),
 		DependencyNamespaceCache:    common.NewSidecarEgressMap(),
 		CnameIdentityCache:          &sync.Map{},
 		ServiceEntryAddressStore:    &ServiceEntryAddressStore{EntryAddresses: map[string]string{}, Addresses: []string{}},

--- a/admiral/pkg/controller/admiral/routingpolicy.go
+++ b/admiral/pkg/controller/admiral/routingpolicy.go
@@ -66,7 +66,7 @@ func (r *RoutingPolicyController) Updated(ctx context.Context, newObj interface{
 	if !ok {
 		return fmt.Errorf("type assertion failed, %v is not of type *v1.RoutingPolicy", newObj)
 	}
-	oldRP, ok := oldObj.(*v1.RoutingPolicy)
+	oldRP, _ := oldObj.(*v1.RoutingPolicy)
 	// oldRp can be nil
 	r.RoutingPolicyHandler.Updated(ctx, newRP, oldRP)
 	return nil

--- a/admiral/pkg/controller/admiral/routingpolicy.go
+++ b/admiral/pkg/controller/admiral/routingpolicy.go
@@ -22,7 +22,7 @@ import (
 // RoutingPolicyHandler interface contains the methods that are required
 type RoutingPolicyHandler interface {
 	Added(ctx context.Context, obj *v1.RoutingPolicy) error
-	Updated(ctx context.Context, obj *v1.RoutingPolicy) error
+	Updated(ctx context.Context, newObj *v1.RoutingPolicy, oldObj *v1.RoutingPolicy) error
 	Deleted(ctx context.Context, obj *v1.RoutingPolicy) error
 }
 
@@ -61,12 +61,14 @@ func (r *RoutingPolicyController) Added(ctx context.Context, obj interface{}) er
 	return nil
 }
 
-func (r *RoutingPolicyController) Updated(ctx context.Context, obj interface{}, oldObj interface{}) error {
-	routingPolicy, ok := obj.(*v1.RoutingPolicy)
+func (r *RoutingPolicyController) Updated(ctx context.Context, newObj interface{}, oldObj interface{}) error {
+	newRP, ok := newObj.(*v1.RoutingPolicy)
 	if !ok {
-		return fmt.Errorf("type assertion failed, %v is not of type *v1.RoutingPolicy", obj)
+		return fmt.Errorf("type assertion failed, %v is not of type *v1.RoutingPolicy", newObj)
 	}
-	r.RoutingPolicyHandler.Updated(ctx, routingPolicy)
+	oldRP, ok := oldObj.(*v1.RoutingPolicy)
+	// oldRp can be nil
+	r.RoutingPolicyHandler.Updated(ctx, newRP, oldRP)
 	return nil
 }
 

--- a/admiral/pkg/controller/admiral/routingpolicy_test.go
+++ b/admiral/pkg/controller/admiral/routingpolicy_test.go
@@ -228,7 +228,7 @@ func TestRoutingPolicyAddUpdateDelete(t *testing.T) {
 	rpObj := makeK8sRoutingPolicyObj(rpName, "namespace1", rp)
 	routingPolicyController.Added(ctx, rpObj)
 
-	if !cmp.Equal(handler.Obj.Spec, rpObj.Spec) {
+	if !cmp.Equal(handler.New.Spec, rpObj.Spec) {
 		t.Errorf("Add should call the handler with the object")
 	}
 
@@ -242,13 +242,13 @@ func TestRoutingPolicyAddUpdateDelete(t *testing.T) {
 
 	routingPolicyController.Updated(ctx, updatedRpObj, rpObj)
 
-	if !cmp.Equal(handler.Obj.Spec, updatedRpObj.Spec) {
+	if !cmp.Equal(handler.New.Spec, updatedRpObj.Spec) {
 		t.Errorf("Update should call the handler with the updated object")
 	}
 
 	routingPolicyController.Deleted(ctx, updatedRpObj)
 
-	if handler.Obj != nil {
+	if handler.New != nil {
 		t.Errorf("Delete should delete the routing policy")
 	}
 

--- a/admiral/pkg/test/mock.go
+++ b/admiral/pkg/test/mock.go
@@ -266,21 +266,24 @@ func (m *MockSidecarHandler) Deleted(ctx context.Context, obj *v1alpha32.Sidecar
 }
 
 type MockRoutingPolicyHandler struct {
-	Obj *admiralV1.RoutingPolicy
+	Old *admiralV1.RoutingPolicy
+	New *admiralV1.RoutingPolicy
 }
 
 func (m *MockRoutingPolicyHandler) Added(ctx context.Context, obj *admiralV1.RoutingPolicy) error {
-	m.Obj = obj
+	m.New = obj
 	return nil
 }
 
 func (m *MockRoutingPolicyHandler) Deleted(ctx context.Context, obj *admiralV1.RoutingPolicy) error {
-	m.Obj = nil
+	m.Old = obj
+	m.New = nil
 	return nil
 }
 
-func (m *MockRoutingPolicyHandler) Updated(ctx context.Context, obj *admiralV1.RoutingPolicy) error {
-	m.Obj = obj
+func (m *MockRoutingPolicyHandler) Updated(ctx context.Context, newObj *admiralV1.RoutingPolicy, oldObj *admiralV1.RoutingPolicy) error {
+	m.New = newObj
+	m.Old = oldObj
 	return nil
 }
 


### PR DESCRIPTION
Task
- Admiral should process new client onboardings for a service with a RoutingPolicy

### Description
What does this change do and why?
- Introduce RoutingPolicyProcessor interface to contain the process() api in order to expose it


Thank you!