### PR TITLE
MESH-5938: Admiral should not create EF for RoutingPolicy on cluster that are not DRS enabled.

### DIFF
--- a/admiral/cmd/admiral/cmd/root.go
+++ b/admiral/cmd/admiral/cmd/root.go
@@ -191,6 +191,7 @@ func GetRootCmd(args []string) *cobra.Command {
 		"The value of envoy filter is to add additional config to the filter config section")
 	rootCmd.PersistentFlags().BoolVar(&params.EnableRoutingPolicy, "enable_routing_policy", false,
 		"If Routing Policy feature needs to be enabled")
+	rootCmd.PersistentFlags().StringSliceVar(&params.RoutingPolicyClusters, "routing_policy_enabled_clusters", []string{}, "The destination clusters to enable routing policy filters on")
 	rootCmd.PersistentFlags().StringSliceVar(&params.ExcludedIdentityList, "excluded_identity_list", []string{},
 		"List of identities which should be excluded from getting processed")
 	rootCmd.PersistentFlags().BoolVar(&params.EnableDiffCheck, "enable_diff_check", true, "Enable diff check")

--- a/admiral/pkg/controller/common/config.go
+++ b/admiral/pkg/controller/common/config.go
@@ -461,6 +461,23 @@ func DoVSRoutingForCluster(cluster string) bool {
 	return false
 }
 
+func DoRoutingPolicyForCluster(cluster string) bool {
+	wrapper.RLock()
+	defer wrapper.RUnlock()
+	if !wrapper.params.EnableRoutingPolicy {
+		return false
+	}
+	for _, c := range wrapper.params.RoutingPolicyClusters {
+		if c == "*" {
+			return true
+		}
+		if c == cluster {
+			return true
+		}
+	}
+	return false
+}
+
 func GetVSRoutingGateways() []string {
 	wrapper.RLock()
 	defer wrapper.RUnlock()

--- a/admiral/pkg/controller/common/config_test.go
+++ b/admiral/pkg/controller/common/config_test.go
@@ -59,6 +59,71 @@ func setupForConfigTests() {
 	}
 }
 
+func TestDoRoutingPolicyForCluster(t *testing.T) {
+	p := AdmiralParams{}
+	type args struct {
+		cluster               string
+		enableRoutingPolicy   bool
+		routingPolicyClusters []string
+	}
+	testCases := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Given enableRoutingPolicy is false" +
+				"Then it should return false irrespective of the routingPolicyClusters",
+			args: args{
+				cluster:             "cluster1",
+				enableRoutingPolicy: false,
+			},
+			want: false,
+		},
+		{
+			name: "Given enableRoutingPolicy is false" +
+				"Then it should return false irrespective of the routingPolicyClusters",
+			args: args{
+				cluster:               "cluster1",
+				enableRoutingPolicy:   false,
+				routingPolicyClusters: []string{"cluster1"},
+			},
+			want: false,
+		},
+		{
+			name: "Given enableRoutingPolicy is true " +
+				"Then it should return true if routingPolicyClusters contains '*'",
+			args: args{
+				cluster:               "cluster1",
+				enableRoutingPolicy:   true,
+				routingPolicyClusters: []string{"*"},
+			},
+			want: true,
+		},
+		{
+			name: "Given enableRoutingPolicy is true " +
+				"Then it should return true if routingPolicyClusters contains exact match",
+			args: args{
+				cluster:               "cluster1",
+				enableRoutingPolicy:   true,
+				routingPolicyClusters: []string{"cluster1"},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p.EnableRoutingPolicy = tc.args.enableRoutingPolicy
+			p.RoutingPolicyClusters = tc.args.routingPolicyClusters
+			ResetSync()
+			InitializeConfig(p)
+
+			assert.Equal(t, tc.want, DoRoutingPolicyForCluster(tc.args.cluster))
+		})
+	}
+}
+
 func TestDoVSRoutingForCluster(t *testing.T) {
 	p := AdmiralParams{}
 

--- a/admiral/pkg/controller/common/config_test.go
+++ b/admiral/pkg/controller/common/config_test.go
@@ -102,6 +102,16 @@ func TestDoRoutingPolicyForCluster(t *testing.T) {
 		},
 		{
 			name: "Given enableRoutingPolicy is true " +
+				"Then it should return false if routingPolicyClusters is empty",
+			args: args{
+				cluster:               "cluster1",
+				enableRoutingPolicy:   true,
+				routingPolicyClusters: []string{},
+			},
+			want: false,
+		},
+		{
+			name: "Given enableRoutingPolicy is true " +
 				"Then it should return true if routingPolicyClusters contains exact match",
 			args: args{
 				cluster:               "cluster1",

--- a/admiral/pkg/controller/common/types.go
+++ b/admiral/pkg/controller/common/types.go
@@ -75,6 +75,7 @@ type AdmiralParams struct {
 	DeprecatedEnvoyFilterVersion             string
 	EnvoyFilterAdditionalConfig              string
 	EnableRoutingPolicy                      bool
+	RoutingPolicyClusters                    []string
 	ExcludedIdentityList                     []string
 	AdditionalEndpointSuffixes               []string
 	AdditionalEndpointLabelFilters           []string


### PR DESCRIPTION
### Description
What does this change do and why?
- Add param routing_policy_enabled_clusters to enable processing
- Update routing_handler to use routing_policy_enabled_clusters before add,update or delete

MESH-5938

Thank you!