### PR TITLE
MESH-0000: remove metrics due to sample limit

### DIFF
--- a/admiral/pkg/clusters/serviceentry.go
+++ b/admiral/pkg/clusters/serviceentry.go
@@ -17,9 +17,6 @@ import (
 	commonUtil "github.com/istio-ecosystem/admiral/admiral/pkg/util"
 	"gopkg.in/yaml.v2"
 
-	"go.opentelemetry.io/otel/attribute"
-	api "go.opentelemetry.io/otel/metric"
-
 	argo "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	model "github.com/istio-ecosystem/admiral/admiral/pkg/apis/admiral/model"
 	v1 "github.com/istio-ecosystem/admiral/admiral/pkg/apis/admiral/v1alpha1"
@@ -101,10 +98,10 @@ func modifyServiceEntryForNewServiceOrPod(
 	defer util.LogElapsedTimeForTask(ctxLogger, "event", "", "", "", "TotalModifySETime")()
 	var modifySEerr error
 	var isServiceEntryModifyCalledForSourceCluster bool
-	totalConfigWriterEvents.Increment(api.WithAttributes(
-		attribute.Key("identity").String(sourceIdentity),
-		attribute.Key("environment").String(env),
-	))
+	//totalConfigWriterEvents.Increment(api.WithAttributes(
+	//	attribute.Key("identity").String(sourceIdentity),
+	//	attribute.Key("environment").String(env),
+	//))
 	// Assigns sourceIdentity, which could have the partition prefix or might not, to the partitionedIdentity
 	// Then, gets the non-partitioned identity and assigns it to sourceIdentity. sourceIdentity will always have the original/non-partitioned identity
 	partitionedIdentity := sourceIdentity

--- a/admiral/pkg/clusters/serviceentry.go
+++ b/admiral/pkg/clusters/serviceentry.go
@@ -17,6 +17,9 @@ import (
 	commonUtil "github.com/istio-ecosystem/admiral/admiral/pkg/util"
 	"gopkg.in/yaml.v2"
 
+	"go.opentelemetry.io/otel/attribute"
+	api "go.opentelemetry.io/otel/metric"
+
 	argo "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	model "github.com/istio-ecosystem/admiral/admiral/pkg/apis/admiral/model"
 	v1 "github.com/istio-ecosystem/admiral/admiral/pkg/apis/admiral/v1alpha1"
@@ -98,10 +101,12 @@ func modifyServiceEntryForNewServiceOrPod(
 	defer util.LogElapsedTimeForTask(ctxLogger, "event", "", "", "", "TotalModifySETime")()
 	var modifySEerr error
 	var isServiceEntryModifyCalledForSourceCluster bool
-	//totalConfigWriterEvents.Increment(api.WithAttributes(
-	//	attribute.Key("identity").String(sourceIdentity),
-	//	attribute.Key("environment").String(env),
-	//))
+	if common.IsAdmiralOperatorMode() {
+		totalConfigWriterEvents.Increment(api.WithAttributes(
+			attribute.Key("identity").String(sourceIdentity),
+			attribute.Key("environment").String(env),
+		))
+	}
 	// Assigns sourceIdentity, which could have the partition prefix or might not, to the partitionedIdentity
 	// Then, gets the non-partitioned identity and assigns it to sourceIdentity. sourceIdentity will always have the original/non-partitioned identity
 	partitionedIdentity := sourceIdentity


### PR DESCRIPTION
### Checklist
🚨 Please review this repository's [contribution guidelines](./CONTRIBUTING.md).

- [ ] I've read and agree to the project's contribution guidelines.
- [ ] I'm requesting to **pull a topic/feature/bugfix branch**.
- [ ] I checked that my code additions will pass code linting checks and unit tests.
- [ ] I updated unit and integration tests (if applicable).
- [ ] I'm ready to notify the team of this contribution.

### Description
These are metrics used to test new monitoring capabilities for Admiral 2.0. They should be removed from the current Admiral as they are overloading the sample limit.