### PR TITLE
call registry from handlers

### DIFF
--- a/admiral/pkg/clusters/clientconnectionconfig_handler_test.go
+++ b/admiral/pkg/clusters/clientconnectionconfig_handler_test.go
@@ -1,10 +1,17 @@
 package clusters
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"github.com/istio-ecosystem/admiral/admiral/pkg/registry"
+	"github.com/istio-ecosystem/admiral/admiral/pkg/test"
+	"github.com/istio-ecosystem/admiral/admiral/pkg/util"
+	"io/ioutil"
+	"net/http"
 	"sync"
 	"testing"
+	"time"
 
 	v1 "github.com/istio-ecosystem/admiral/admiral/pkg/apis/admiral/v1alpha1"
 	"github.com/istio-ecosystem/admiral/admiral/pkg/controller/admiral"
@@ -123,6 +130,330 @@ func TestHandleEventForClientConnectionConfig(t *testing.T) {
 		})
 	}
 
+}
+
+func TestClientConnectionConfigHandler_Added(t *testing.T) {
+	p := common.AdmiralParams{
+		KubeconfigPath: "testdata/fake.config",
+		LabelSet: &common.LabelSet{
+			EnvKey:                  "admiral.io/env",
+			AdmiralCRDIdentityLabel: "identity",
+		},
+		EnableSAN:                  true,
+		SANPrefix:                  "prefix",
+		HostnameSuffix:             "mesh",
+		SyncNamespace:              "ns",
+		CacheReconcileDuration:     10 * time.Second,
+		Profile:                    common.AdmiralProfileDefault,
+		AdmiralStateSyncerMode:     true,
+		AdmiralStateSyncerClusters: []string{"test-k8s"},
+	}
+	common.ResetSync()
+	common.InitializeConfig(p)
+	remoteRegistry, _ := InitAdmiral(context.Background(), p)
+	dummyRespBody := ioutil.NopCloser(bytes.NewBufferString("dummyRespBody"))
+	validRegistryClient := registry.NewDefaultRegistryClient()
+	validClient := test.MockClient{
+		ExpectedPutResponse: &http.Response{
+			StatusCode: 200,
+			Body:       dummyRespBody,
+		},
+		ExpectedPutErr: nil,
+		ExpectedConfig: &util.Config{Host: "host", BaseURI: "v1"},
+	}
+	validRegistryClient.Client = &validClient
+	invalidRegistryClient := registry.NewDefaultRegistryClient()
+	invalidClient := test.MockClient{
+		ExpectedPutResponse: &http.Response{
+			StatusCode: 404,
+			Body:       dummyRespBody,
+		},
+		ExpectedPutErr: fmt.Errorf("failed private auth call"),
+		ExpectedConfig: &util.Config{Host: "host", BaseURI: "v1"},
+	}
+	invalidRegistryClient.Client = &invalidClient
+
+	testCases := []struct {
+		name                     string
+		ctx                      context.Context
+		clientConnectionSettings *v1.ClientConnectionConfig
+		registryClient           *registry.RegistryClient
+		expectedError            error
+	}{
+		{
+			name: "Given valid params to Added func " +
+				"When modifySE func returns an error " +
+				"Then the func should return an error",
+			clientConnectionSettings: &v1.ClientConnectionConfig{
+				ObjectMeta: apiMachineryMetaV1.ObjectMeta{
+					Name:      "ccsName",
+					Namespace: "testns",
+					Labels: map[string]string{
+						"admiral.io/env": "testEnv",
+						"identity":       "testId",
+					},
+				},
+			},
+			ctx:            context.WithValue(context.Background(), "txId", "txidvalue"),
+			registryClient: validRegistryClient,
+			expectedError:  fmt.Errorf("op=Add type=ClientConnectionConfig name=ccsName cluster=test-k8s error=task=Update name=testEnv namespace=testId cluster= message=processing skipped during cache warm up state for env=testEnv identity=testId"),
+		},
+		{
+			name: "Given valid params to Added func " +
+				"When registry func returns an error " +
+				"Then the func should proceed",
+			clientConnectionSettings: &v1.ClientConnectionConfig{
+				ObjectMeta: apiMachineryMetaV1.ObjectMeta{
+					Name:      "ccsName",
+					Namespace: "testns",
+					Labels: map[string]string{
+						"admiral.io/env": "testEnv",
+						"identity":       "testId",
+					},
+				},
+			},
+			ctx:            context.WithValue(context.Background(), "txId", "txidvalue"),
+			registryClient: invalidRegistryClient,
+			expectedError:  fmt.Errorf("op=Add type=ClientConnectionConfig name=ccsName cluster=test-k8s error=task=Update name=testEnv namespace=testId cluster= message=processing skipped during cache warm up state for env=testEnv identity=testId"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			remoteRegistry.RegistryClient = tc.registryClient
+			cccHandler := ClientConnectionConfigHandler{
+				RemoteRegistry: remoteRegistry,
+				ClusterID:      "test-k8s",
+			}
+			actualError := cccHandler.Added(tc.ctx, tc.clientConnectionSettings)
+			if tc.expectedError != nil {
+				if actualError == nil {
+					t.Fatalf("expected error %s but got nil", tc.expectedError.Error())
+				}
+				assert.Equal(t, tc.expectedError.Error(), actualError.Error())
+			} else {
+				if actualError != nil {
+					t.Fatalf("expected error nil but got %s", actualError.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestClientConnectionConfigHandler_Updated(t *testing.T) {
+	p := common.AdmiralParams{
+		KubeconfigPath: "testdata/fake.config",
+		LabelSet: &common.LabelSet{
+			EnvKey:                  "admiral.io/env",
+			AdmiralCRDIdentityLabel: "identity",
+		},
+		EnableSAN:                  true,
+		SANPrefix:                  "prefix",
+		HostnameSuffix:             "mesh",
+		SyncNamespace:              "ns",
+		CacheReconcileDuration:     10 * time.Second,
+		Profile:                    common.AdmiralProfileDefault,
+		AdmiralStateSyncerMode:     true,
+		AdmiralStateSyncerClusters: []string{"test-k8s"},
+	}
+	common.ResetSync()
+	common.InitializeConfig(p)
+	remoteRegistry, _ := InitAdmiral(context.Background(), p)
+	dummyRespBody := ioutil.NopCloser(bytes.NewBufferString("dummyRespBody"))
+	validRegistryClient := registry.NewDefaultRegistryClient()
+	validClient := test.MockClient{
+		ExpectedPutResponse: &http.Response{
+			StatusCode: 200,
+			Body:       dummyRespBody,
+		},
+		ExpectedPutErr: nil,
+		ExpectedConfig: &util.Config{Host: "host", BaseURI: "v1"},
+	}
+	validRegistryClient.Client = &validClient
+	invalidRegistryClient := registry.NewDefaultRegistryClient()
+	invalidClient := test.MockClient{
+		ExpectedPutResponse: &http.Response{
+			StatusCode: 404,
+			Body:       dummyRespBody,
+		},
+		ExpectedPutErr: fmt.Errorf("failed private auth call"),
+		ExpectedConfig: &util.Config{Host: "host", BaseURI: "v1"},
+	}
+	invalidRegistryClient.Client = &invalidClient
+
+	testCases := []struct {
+		name                     string
+		ctx                      context.Context
+		clientConnectionSettings *v1.ClientConnectionConfig
+		registryClient           *registry.RegistryClient
+		expectedError            error
+	}{
+		{
+			name: "Given valid params to Updated func " +
+				"When modifySE func returns an error " +
+				"Then the func should return an error",
+			clientConnectionSettings: &v1.ClientConnectionConfig{
+				ObjectMeta: apiMachineryMetaV1.ObjectMeta{
+					Name:      "ccsName",
+					Namespace: "testns",
+					Labels: map[string]string{
+						"admiral.io/env": "testEnv",
+						"identity":       "testId",
+					},
+				},
+			},
+			ctx:            context.WithValue(context.Background(), "txId", "txidvalue"),
+			registryClient: validRegistryClient,
+			expectedError:  fmt.Errorf("op=Update type=ClientConnectionConfig name=ccsName cluster=test-k8s error=task=Update name=testEnv namespace=testId cluster= message=processing skipped during cache warm up state for env=testEnv identity=testId"),
+		},
+		{
+			name: "Given valid params to Updated func " +
+				"When registry func returns an error " +
+				"Then the func should proceed",
+			clientConnectionSettings: &v1.ClientConnectionConfig{
+				ObjectMeta: apiMachineryMetaV1.ObjectMeta{
+					Name:      "ccsName",
+					Namespace: "testns",
+					Labels: map[string]string{
+						"admiral.io/env": "testEnv",
+						"identity":       "testId",
+					},
+				},
+			},
+			ctx:            context.WithValue(context.Background(), "txId", "txidvalue"),
+			registryClient: invalidRegistryClient,
+			expectedError:  fmt.Errorf("op=Update type=ClientConnectionConfig name=ccsName cluster=test-k8s error=task=Update name=testEnv namespace=testId cluster= message=processing skipped during cache warm up state for env=testEnv identity=testId"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			remoteRegistry.RegistryClient = tc.registryClient
+			cccHandler := ClientConnectionConfigHandler{
+				RemoteRegistry: remoteRegistry,
+				ClusterID:      "test-k8s",
+			}
+			actualError := cccHandler.Updated(tc.ctx, tc.clientConnectionSettings)
+			if tc.expectedError != nil {
+				if actualError == nil {
+					t.Fatalf("expected error %s but got nil", tc.expectedError.Error())
+				}
+				assert.Equal(t, tc.expectedError.Error(), actualError.Error())
+			} else {
+				if actualError != nil {
+					t.Fatalf("expected error nil but got %s", actualError.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestClientConnectionConfigHandler_Deleted(t *testing.T) {
+	p := common.AdmiralParams{
+		KubeconfigPath: "testdata/fake.config",
+		LabelSet: &common.LabelSet{
+			EnvKey:                  "admiral.io/env",
+			AdmiralCRDIdentityLabel: "identity",
+		},
+		EnableSAN:                  true,
+		SANPrefix:                  "prefix",
+		HostnameSuffix:             "mesh",
+		SyncNamespace:              "ns",
+		CacheReconcileDuration:     10 * time.Second,
+		Profile:                    common.AdmiralProfileDefault,
+		AdmiralStateSyncerMode:     true,
+		AdmiralStateSyncerClusters: []string{"test-k8s"},
+	}
+	common.ResetSync()
+	common.InitializeConfig(p)
+	remoteRegistry, _ := InitAdmiral(context.Background(), p)
+	dummyRespBody := ioutil.NopCloser(bytes.NewBufferString("dummyRespBody"))
+	validRegistryClient := registry.NewDefaultRegistryClient()
+	validClient := test.MockClient{
+		ExpectedDeleteResponse: &http.Response{
+			StatusCode: 200,
+			Body:       dummyRespBody,
+		},
+		ExpectedDeleteErr: nil,
+		ExpectedConfig:    &util.Config{Host: "host", BaseURI: "v1"},
+	}
+	validRegistryClient.Client = &validClient
+	invalidRegistryClient := registry.NewDefaultRegistryClient()
+	invalidClient := test.MockClient{
+		ExpectedDeleteResponse: &http.Response{
+			StatusCode: 404,
+			Body:       dummyRespBody,
+		},
+		ExpectedDeleteErr: fmt.Errorf("failed private auth call"),
+		ExpectedConfig:    &util.Config{Host: "host", BaseURI: "v1"},
+	}
+	invalidRegistryClient.Client = &invalidClient
+
+	testCases := []struct {
+		name                     string
+		ctx                      context.Context
+		clientConnectionSettings *v1.ClientConnectionConfig
+		registryClient           *registry.RegistryClient
+		expectedError            error
+	}{
+		{
+			name: "Given valid params to Deleted func " +
+				"When modifySE func returns an error " +
+				"Then the func should return an error",
+			clientConnectionSettings: &v1.ClientConnectionConfig{
+				ObjectMeta: apiMachineryMetaV1.ObjectMeta{
+					Name:      "ccsName",
+					Namespace: "testns",
+					Labels: map[string]string{
+						"admiral.io/env": "testEnv",
+						"identity":       "testId",
+					},
+				},
+			},
+			ctx:            context.WithValue(context.Background(), "txId", "txidvalue"),
+			registryClient: validRegistryClient,
+			expectedError:  fmt.Errorf("op=Delete type=ClientConnectionConfig name=ccsName cluster=test-k8s error=task=Update name=testEnv namespace=testId cluster= message=processing skipped during cache warm up state for env=testEnv identity=testId"),
+		},
+		{
+			name: "Given valid params to Deleted func " +
+				"When registry func returns an error " +
+				"Then the func should proceed",
+			clientConnectionSettings: &v1.ClientConnectionConfig{
+				ObjectMeta: apiMachineryMetaV1.ObjectMeta{
+					Name:      "ccsName",
+					Namespace: "testns",
+					Labels: map[string]string{
+						"admiral.io/env": "testEnv",
+						"identity":       "testId",
+					},
+				},
+			},
+			ctx:            context.WithValue(context.Background(), "txId", "txidvalue"),
+			registryClient: invalidRegistryClient,
+			expectedError:  fmt.Errorf("op=Delete type=ClientConnectionConfig name=ccsName cluster=test-k8s error=task=Update name=testEnv namespace=testId cluster= message=processing skipped during cache warm up state for env=testEnv identity=testId"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			remoteRegistry.RegistryClient = tc.registryClient
+			cccHandler := ClientConnectionConfigHandler{
+				RemoteRegistry: remoteRegistry,
+				ClusterID:      "test-k8s",
+			}
+			actualError := cccHandler.Deleted(tc.ctx, tc.clientConnectionSettings)
+			if tc.expectedError != nil {
+				if actualError == nil {
+					t.Fatalf("expected error %s but got nil", tc.expectedError.Error())
+				}
+				assert.Equal(t, tc.expectedError.Error(), actualError.Error())
+			} else {
+				if actualError != nil {
+					t.Fatalf("expected error nil but got %s", actualError.Error())
+				}
+			}
+		})
+	}
 }
 
 func TestDelete(t *testing.T) {

--- a/admiral/pkg/clusters/clientdiscovery_handler.go
+++ b/admiral/pkg/clusters/clientdiscovery_handler.go
@@ -29,9 +29,24 @@ func HandleEventForClientDiscovery(ctx context.Context, event admiral.EventType,
 	if len(globalIdentifier) == 0 {
 		return nil
 	}
+	ctxLogger := common.GetCtxLogger(ctx, globalIdentifier, "")
 
 	ctx = context.WithValue(ctx, "clusterName", clusterName)
 	ctx = context.WithValue(ctx, "eventResourceType", obj.Type)
+
+	if common.IsAdmiralStateSyncerMode() && common.IsStateSyncerCluster(clusterName) {
+		if event != admiral.Delete {
+			err := remoteRegistry.RegistryClient.PutHostingData(clusterName, obj.Namespace, obj.Name, globalIdentifier, obj.Type, ctx.Value("txId").(string), obj)
+			if err != nil {
+				ctxLogger.Errorf(common.CtxLogFormat, event, obj.Name, obj.Namespace, clusterName, "failed to put "+obj.Type+" hosting data for identity="+globalIdentifier)
+			}
+		} else {
+			err := remoteRegistry.RegistryClient.DeleteHostingData(clusterName, obj.Namespace, obj.Name, globalIdentifier, obj.Type, ctx.Value("txId").(string))
+			if err != nil {
+				ctxLogger.Errorf(common.CtxLogFormat, event, obj.Name, obj.Namespace, clusterName, "failed to delete "+obj.Type+" hosting data for identity="+globalIdentifier)
+			}
+		}
+	}
 
 	if remoteRegistry.AdmiralCache != nil {
 

--- a/admiral/pkg/clusters/deployment_handler.go
+++ b/admiral/pkg/clusters/deployment_handler.go
@@ -52,6 +52,21 @@ func HandleEventForDeployment(ctx context.Context, event admiral.EventType, obj 
 	ctx = context.WithValue(ctx, common.ClusterName, clusterName)
 	ctx = context.WithValue(ctx, common.EventResourceType, common.Deployment)
 
+	if common.IsAdmiralStateSyncerMode() && common.IsStateSyncerCluster(clusterName) {
+		// the globalIdentifier is partition + "." + assetAlias, not just assetAlias
+		if event != admiral.Delete {
+			err := remoteRegistry.RegistryClient.PutHostingData(clusterName, obj.Namespace, obj.Name, globalIdentifier, common.Deployment, ctx.Value("txId").(string), obj)
+			if err != nil {
+				log.Errorf(LogFormat, event, common.DeploymentResourceType, obj.Name, clusterName, "failed to put "+common.Deployment+" hosting data for identity="+globalIdentifier+"with err: "+err.Error())
+			}
+		} else {
+			err := remoteRegistry.RegistryClient.DeleteHostingData(clusterName, obj.Namespace, obj.Name, globalIdentifier, common.Deployment, ctx.Value("txId").(string))
+			if err != nil {
+				log.Errorf(LogFormat, event, common.DeploymentResourceType, obj.Name, clusterName, "failed to delete "+common.Deployment+" hosting data for identity="+globalIdentifier+"with err: "+err.Error())
+			}
+		}
+	}
+
 	if remoteRegistry.AdmiralCache != nil {
 		if remoteRegistry.AdmiralCache.IdentityClusterCache != nil {
 			remoteRegistry.AdmiralCache.IdentityClusterCache.Put(globalIdentifier, clusterName, clusterName)

--- a/admiral/pkg/clusters/deployment_handler_test.go
+++ b/admiral/pkg/clusters/deployment_handler_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/istio-ecosystem/admiral/admiral/pkg/registry"
 	"github.com/istio-ecosystem/admiral/admiral/pkg/test"
 	"github.com/istio-ecosystem/admiral/admiral/pkg/util"
+	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"sync"
@@ -138,38 +139,6 @@ func TestDeploymentHandler(t *testing.T) {
 	remoteRegistry.AdmiralCache.GlobalTrafficCache = gtpCache
 	handler.RemoteRegistry = remoteRegistry
 	handler.ClusterID = "cluster-1"
-	dummyRespBody := ioutil.NopCloser(bytes.NewBufferString("dummyRespBody"))
-	validRegistryClient := registry.NewDefaultRegistryClient()
-	validClient := test.MockClient{
-		ExpectedPutResponse: &http.Response{
-			StatusCode: 200,
-			Body:       dummyRespBody,
-		},
-		ExpectedPutErr: nil,
-		ExpectedDeleteResponse: &http.Response{
-			StatusCode: 200,
-			Body:       dummyRespBody,
-		},
-		ExpectedDeleteErr: nil,
-		ExpectedConfig:    &util.Config{Host: "host", BaseURI: "v1"},
-	}
-	validRegistryClient.Client = &validClient
-	invalidRegistryClient := registry.NewDefaultRegistryClient()
-	invalidClient := test.MockClient{
-		ExpectedPutResponse: &http.Response{
-			StatusCode: 404,
-			Body:       dummyRespBody,
-		},
-		ExpectedPutErr: fmt.Errorf("failed private auth call"),
-		ExpectedDeleteResponse: &http.Response{
-			StatusCode: 404,
-			Body:       dummyRespBody,
-		},
-		ExpectedDeleteErr: fmt.Errorf("failed private auth call"),
-		ExpectedConfig:    &util.Config{Host: "host", BaseURI: "v1"},
-	}
-	invalidRegistryClient.Client = &invalidClient
-
 	deployment := appsV1.Deployment{
 		ObjectMeta: metaV1.ObjectMeta{
 			Name:      "test",
@@ -195,7 +164,6 @@ func TestDeploymentHandler(t *testing.T) {
 		expectedDeploymentCacheKey   string
 		expectedIdentityCacheValue   *v1.GlobalTrafficPolicy
 		expectedDeploymentCacheValue *appsV1.Deployment
-		registryClient               *registry.RegistryClient
 	}{
 		{
 			name:                         "Shouldn't throw errors when called",
@@ -203,15 +171,6 @@ func TestDeploymentHandler(t *testing.T) {
 			expectedDeploymentCacheKey:   "myGTP1",
 			expectedIdentityCacheValue:   nil,
 			expectedDeploymentCacheValue: nil,
-			registryClient:               validRegistryClient,
-		},
-		{
-			name:                         "Should log an error for failed registry call",
-			addedDeployment:              &deployment,
-			expectedDeploymentCacheKey:   "myGTP1",
-			expectedIdentityCacheValue:   nil,
-			expectedDeploymentCacheValue: nil,
-			registryClient:               invalidRegistryClient,
 		},
 	}
 
@@ -226,13 +185,124 @@ func TestDeploymentHandler(t *testing.T) {
 			gtpCache.identityCache = make(map[string]*v1.GlobalTrafficPolicy)
 			gtpCache.mutex = &sync.Mutex{}
 			handler.RemoteRegistry.AdmiralCache.GlobalTrafficCache = gtpCache
-			handler.RemoteRegistry.RegistryClient = c.registryClient
 			handler.Added(ctx, &deployment)
 			ns := handler.RemoteRegistry.AdmiralCache.IdentityClusterNamespaceCache.Get("bar").Get("cluster-1").GetKeys()[0]
 			if ns != "namespace" {
 				t.Errorf("expected namespace: %v but got %v", "namespace", ns)
 			}
 			handler.Deleted(ctx, &deployment)
+		})
+	}
+}
+
+func TestCallRegistryForDeployment(t *testing.T) {
+	p := common.AdmiralParams{
+		KubeconfigPath: "testdata/fake.config",
+		LabelSet: &common.LabelSet{
+			EnvKey:                  "admiral.io/env",
+			AdmiralCRDIdentityLabel: "identity",
+		},
+		Profile:                    common.AdmiralProfileDefault,
+		AdmiralStateSyncerMode:     true,
+		AdmiralStateSyncerClusters: []string{"test-k8s"},
+	}
+	common.ResetSync()
+	common.InitializeConfig(p)
+	remoteRegistry, _ := InitAdmiral(context.Background(), p)
+	dummyRespBody := ioutil.NopCloser(bytes.NewBufferString("dummyRespBody"))
+	validRegistryClient := registry.NewDefaultRegistryClient()
+	validClient := test.MockClient{
+		ExpectedPutResponse: &http.Response{
+			StatusCode: 200,
+			Body:       dummyRespBody,
+		},
+		ExpectedPutErr: nil,
+		ExpectedConfig: &util.Config{Host: "host", BaseURI: "v1"},
+	}
+	validRegistryClient.Client = &validClient
+	invalidRegistryClient := registry.NewDefaultRegistryClient()
+	invalidClient := test.MockClient{
+		ExpectedDeleteResponse: &http.Response{
+			StatusCode: 404,
+			Body:       dummyRespBody,
+		},
+		ExpectedDeleteErr: fmt.Errorf("failed private auth call"),
+		ExpectedConfig:    &util.Config{Host: "host", BaseURI: "v1"},
+	}
+	invalidRegistryClient.Client = &invalidClient
+	deploy := &appsV1.Deployment{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:      "test",
+			Namespace: "namespace",
+			Labels:    map[string]string{"identity": "app1"},
+		},
+		Spec: appsV1.DeploymentSpec{
+			Selector: &metaV1.LabelSelector{
+				MatchLabels: map[string]string{"identity": "bar"},
+			},
+			Template: coreV1.PodTemplateSpec{
+				ObjectMeta: metaV1.ObjectMeta{
+					Labels: map[string]string{"identity": "bar", "istio-injected": "true", "env": "dev"},
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name           string
+		ctx            context.Context
+		obj            *appsV1.Deployment
+		registryClient *registry.RegistryClient
+		event          admiral.EventType
+		expectedError  error
+	}{
+		{
+			name: "Given valid registry client " +
+				"When calling for add event " +
+				"Then error should be nil",
+			obj:            deploy,
+			ctx:            context.WithValue(context.Background(), "txId", "txidvalue"),
+			registryClient: validRegistryClient,
+			event:          admiral.Add,
+			expectedError:  nil,
+		},
+		{
+			name: "Given valid registry client " +
+				"When calling for update event " +
+				"Then error should be nil",
+			obj:            deploy,
+			ctx:            context.WithValue(context.Background(), "txId", "txidvalue"),
+			registryClient: validRegistryClient,
+			event:          admiral.Update,
+			expectedError:  nil,
+		},
+		{
+			name: "Given valid params to call registry func " +
+				"When registry func returns an error " +
+				"Then handler should receive an error",
+			obj:            deploy,
+			ctx:            context.WithValue(context.Background(), "txId", "txidvalue"),
+			registryClient: invalidRegistryClient,
+			event:          admiral.Delete,
+			expectedError:  fmt.Errorf("op=Delete type=deployment name=test cluster=test-k8s message=failed to Delete deployment with err: failed private auth call"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			remoteRegistry.RegistryClient = tc.registryClient
+			clusterName := "test-k8s"
+			actualError := callRegistryForDeployment(tc.ctx, tc.event, remoteRegistry, "test.testId", clusterName, tc.obj)
+			if tc.expectedError != nil {
+				if actualError == nil {
+					t.Fatalf("expected error %s but got nil", tc.expectedError.Error())
+				}
+				assert.Equal(t, tc.expectedError.Error(), actualError.Error())
+			} else {
+				if actualError != nil {
+					t.Fatalf("expected error nil but got %s", actualError.Error())
+				}
+			}
 		})
 	}
 }

--- a/admiral/pkg/clusters/globaltraffic_handler.go
+++ b/admiral/pkg/clusters/globaltraffic_handler.go
@@ -64,6 +64,12 @@ func (g *globalTrafficCache) Delete(identity string, environment string) error {
 
 func (gtp *GlobalTrafficHandler) Added(ctx context.Context, obj *v1.GlobalTrafficPolicy) error {
 	log.Infof(LogFormat, "Added", "globaltrafficpolicy", obj.Name, gtp.ClusterID, fmt.Sprintf("received gtp: %v", obj))
+	if common.IsAdmiralStateSyncerMode() && common.IsStateSyncerCluster(gtp.ClusterID) {
+		err := gtp.RemoteRegistry.RegistryClient.PutCustomData(gtp.ClusterID, obj.Namespace, obj.Name, "GlobalTrafficPolicy", ctx.Value("txId").(string), obj)
+		if err != nil {
+			log.Errorf(LogFormat, "Added", "globaltrafficpolicy", obj.Name, gtp.ClusterID, "failed to put GlobalTrafficPolicy custom data")
+		}
+	}
 	err := HandleEventForGlobalTrafficPolicy(ctx, admiral.Add, obj, gtp.RemoteRegistry, gtp.ClusterID, modifyServiceEntryForNewServiceOrPod)
 	if err != nil {
 		return fmt.Errorf(LogErrFormat, "Added", "globaltrafficpolicy", obj.Name, gtp.ClusterID, err.Error())
@@ -73,6 +79,12 @@ func (gtp *GlobalTrafficHandler) Added(ctx context.Context, obj *v1.GlobalTraffi
 
 func (gtp *GlobalTrafficHandler) Updated(ctx context.Context, obj *v1.GlobalTrafficPolicy) error {
 	log.Infof(LogFormat, "Updated", "globaltrafficpolicy", obj.Name, gtp.ClusterID, fmt.Sprintf("received gtp: %v", obj))
+	if common.IsAdmiralStateSyncerMode() && common.IsStateSyncerCluster(gtp.ClusterID) {
+		err := gtp.RemoteRegistry.RegistryClient.PutCustomData(gtp.ClusterID, obj.Namespace, obj.Name, "GlobalTrafficPolicy", ctx.Value("txId").(string), obj)
+		if err != nil {
+			log.Errorf(LogFormat, "Updated", "globaltrafficpolicy", obj.Name, gtp.ClusterID, "failed to put GlobalTrafficPolicy custom data")
+		}
+	}
 	err := HandleEventForGlobalTrafficPolicy(ctx, admiral.Update, obj, gtp.RemoteRegistry, gtp.ClusterID, modifyServiceEntryForNewServiceOrPod)
 	if err != nil {
 		return fmt.Errorf(LogErrFormat, "Updated", "globaltrafficpolicy", obj.Name, gtp.ClusterID, err.Error())
@@ -81,6 +93,12 @@ func (gtp *GlobalTrafficHandler) Updated(ctx context.Context, obj *v1.GlobalTraf
 }
 
 func (gtp *GlobalTrafficHandler) Deleted(ctx context.Context, obj *v1.GlobalTrafficPolicy) error {
+	if common.IsAdmiralStateSyncerMode() && common.IsStateSyncerCluster(gtp.ClusterID) {
+		err := gtp.RemoteRegistry.RegistryClient.DeleteCustomData(gtp.ClusterID, obj.Namespace, obj.Name, "GlobalTrafficPolicy", ctx.Value("txId").(string))
+		if err != nil {
+			log.Errorf(LogFormat, "Deleted", "globaltrafficpolicy", obj.Name, gtp.ClusterID, "failed to delete GlobalTrafficPolicy custom data")
+		}
+	}
 	err := HandleEventForGlobalTrafficPolicy(ctx, admiral.Delete, obj, gtp.RemoteRegistry, gtp.ClusterID, modifyServiceEntryForNewServiceOrPod)
 	if err != nil {
 		return fmt.Errorf(LogErrFormat, "Deleted", "globaltrafficpolicy", obj.Name, gtp.ClusterID, err.Error())

--- a/admiral/pkg/clusters/globaltraffic_handler_test.go
+++ b/admiral/pkg/clusters/globaltraffic_handler_test.go
@@ -1,9 +1,16 @@
 package clusters
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"github.com/istio-ecosystem/admiral/admiral/pkg/registry"
+	"github.com/istio-ecosystem/admiral/admiral/pkg/test"
+	"github.com/istio-ecosystem/admiral/admiral/pkg/util"
+	"io/ioutil"
+	"net/http"
 	"testing"
+	"time"
 
 	v1 "github.com/istio-ecosystem/admiral/admiral/pkg/apis/admiral/v1alpha1"
 	"github.com/istio-ecosystem/admiral/admiral/pkg/controller/admiral"
@@ -27,7 +34,7 @@ func TestHandleEventForGlobalTrafficPolicy(t *testing.T) {
 	p := common.AdmiralParams{
 		KubeconfigPath: "testdata/fake.config",
 	}
-	registry, _ := InitAdmiral(context.Background(), p)
+	remoteRegistry, _ := InitAdmiral(context.Background(), p)
 
 	seFunc := func(ctx context.Context, event admiral.EventType, env string, sourceIdentity string, remoteRegistry *RemoteRegistry) (map[string]*networkingAlpha3.ServiceEntry, error) {
 		return nil, nil
@@ -95,8 +102,362 @@ func TestHandleEventForGlobalTrafficPolicy(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			err := HandleEventForGlobalTrafficPolicy(ctx, event, c.gtp, registry, "testcluster", c.seFunc)
+			err := HandleEventForGlobalTrafficPolicy(ctx, event, c.gtp, remoteRegistry, "testcluster", c.seFunc)
 			assert.Equal(t, err != nil, c.doesError)
+		})
+	}
+}
+
+func TestGlobalTrafficHandler_Added(t *testing.T) {
+	p := common.AdmiralParams{
+		KubeconfigPath: "testdata/fake.config",
+		LabelSet: &common.LabelSet{
+			WorkloadIdentityKey:     "identity",
+			EnvKey:                  "admiral.io/env",
+			AdmiralCRDIdentityLabel: "identity",
+			PriorityKey:             "priority",
+		},
+		EnableSAN:                  true,
+		SANPrefix:                  "prefix",
+		HostnameSuffix:             "mesh",
+		SyncNamespace:              "ns",
+		CacheReconcileDuration:     10 * time.Second,
+		Profile:                    common.AdmiralProfileDefault,
+		AdmiralStateSyncerMode:     true,
+		AdmiralStateSyncerClusters: []string{"test-k8s"},
+	}
+	common.ResetSync()
+	common.InitializeConfig(p)
+	remoteRegistry, _ := InitAdmiral(context.Background(), p)
+	dummyRespBody := ioutil.NopCloser(bytes.NewBufferString("dummyRespBody"))
+	validRegistryClient := registry.NewDefaultRegistryClient()
+	validClient := test.MockClient{
+		ExpectedPutResponse: &http.Response{
+			StatusCode: 200,
+			Body:       dummyRespBody,
+		},
+		ExpectedPutErr: nil,
+		ExpectedConfig: &util.Config{Host: "host", BaseURI: "v1"},
+	}
+	validRegistryClient.Client = &validClient
+	invalidRegistryClient := registry.NewDefaultRegistryClient()
+	invalidClient := test.MockClient{
+		ExpectedPutResponse: &http.Response{
+			StatusCode: 404,
+			Body:       dummyRespBody,
+		},
+		ExpectedPutErr: fmt.Errorf("failed private auth call"),
+		ExpectedConfig: &util.Config{Host: "host", BaseURI: "v1"},
+	}
+	invalidRegistryClient.Client = &invalidClient
+
+	testCases := []struct {
+		name                string
+		ctx                 context.Context
+		globalTrafficPolicy *v1.GlobalTrafficPolicy
+		registryClient      *registry.RegistryClient
+		expectedError       error
+	}{
+		{
+			name: "Given valid params to Added func " +
+				"When no func returns an error " +
+				"Then the func proceed to modifySe",
+			globalTrafficPolicy: &v1.GlobalTrafficPolicy{
+				ObjectMeta: apiMachineryMetaV1.ObjectMeta{
+					Name:        "testgtp",
+					Labels:      map[string]string{"identity": "testapp"},
+					Annotations: map[string]string{"admiral.io/env": "testenv"},
+				},
+			},
+			ctx:            context.WithValue(context.Background(), "txId", "txidvalue"),
+			registryClient: validRegistryClient,
+			expectedError:  fmt.Errorf("op=Added type=globaltrafficpolicy name=testgtp cluster=test-k8s error=task=Update name=testenv namespace=testapp cluster= message=processing skipped during cache warm up state for env=testenv identity=testapp"),
+		},
+		{
+			name: "Given valid params to Added func " +
+				"When handleEvent func returns an error " +
+				"Then the func should return an error",
+			globalTrafficPolicy: &v1.GlobalTrafficPolicy{
+				ObjectMeta: apiMachineryMetaV1.ObjectMeta{
+					Name:        "testgtp",
+					Annotations: map[string]string{"admiral.io/env": "testenv"},
+				},
+			},
+			ctx:            context.WithValue(context.Background(), "txId", "txidvalue"),
+			registryClient: validRegistryClient,
+			expectedError:  fmt.Errorf("op=Added type=globaltrafficpolicy name=testgtp cluster=test-k8s error=op=Event type=globaltrafficpolicy name=testgtp cluster=test-k8s message=Skipped as 'identity was not found', namespace="),
+		},
+		{
+			name: "Given valid params to Added func " +
+				"When registry func returns an error " +
+				"Then the func should proceed",
+			globalTrafficPolicy: &v1.GlobalTrafficPolicy{
+				ObjectMeta: apiMachineryMetaV1.ObjectMeta{
+					Name:        "testgtp",
+					Labels:      map[string]string{"identity": "testapp"},
+					Annotations: map[string]string{"admiral.io/env": "testenv"},
+				},
+			},
+			ctx:            context.WithValue(context.Background(), "txId", "txidvalue"),
+			registryClient: invalidRegistryClient,
+			expectedError:  fmt.Errorf("op=Added type=globaltrafficpolicy name=testgtp cluster=test-k8s error=task=Update name=testenv namespace=testapp cluster= message=processing skipped during cache warm up state for env=testenv identity=testapp"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			remoteRegistry.RegistryClient = tc.registryClient
+			gtpHandler := GlobalTrafficHandler{
+				RemoteRegistry: remoteRegistry,
+				ClusterID:      "test-k8s",
+			}
+			actualError := gtpHandler.Added(tc.ctx, tc.globalTrafficPolicy)
+			if tc.expectedError != nil {
+				if actualError == nil {
+					t.Fatalf("expected error %s but got nil", tc.expectedError.Error())
+				}
+				assert.Equal(t, tc.expectedError.Error(), actualError.Error())
+			} else {
+				if actualError != nil {
+					t.Fatalf("expected error nil but got %s", actualError.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestGlobalTrafficHandler_Updated(t *testing.T) {
+	p := common.AdmiralParams{
+		KubeconfigPath: "testdata/fake.config",
+		LabelSet: &common.LabelSet{
+			WorkloadIdentityKey:     "identity",
+			EnvKey:                  "admiral.io/env",
+			AdmiralCRDIdentityLabel: "identity",
+			PriorityKey:             "priority",
+		},
+		EnableSAN:                  true,
+		SANPrefix:                  "prefix",
+		HostnameSuffix:             "mesh",
+		SyncNamespace:              "ns",
+		CacheReconcileDuration:     10 * time.Second,
+		Profile:                    common.AdmiralProfileDefault,
+		AdmiralStateSyncerMode:     true,
+		AdmiralStateSyncerClusters: []string{"test-k8s"},
+	}
+	common.ResetSync()
+	common.InitializeConfig(p)
+	remoteRegistry, _ := InitAdmiral(context.Background(), p)
+	dummyRespBody := ioutil.NopCloser(bytes.NewBufferString("dummyRespBody"))
+	validRegistryClient := registry.NewDefaultRegistryClient()
+	validClient := test.MockClient{
+		ExpectedPutResponse: &http.Response{
+			StatusCode: 200,
+			Body:       dummyRespBody,
+		},
+		ExpectedPutErr: nil,
+		ExpectedConfig: &util.Config{Host: "host", BaseURI: "v1"},
+	}
+	validRegistryClient.Client = &validClient
+	invalidRegistryClient := registry.NewDefaultRegistryClient()
+	invalidClient := test.MockClient{
+		ExpectedPutResponse: &http.Response{
+			StatusCode: 404,
+			Body:       dummyRespBody,
+		},
+		ExpectedPutErr: fmt.Errorf("failed private auth call"),
+		ExpectedConfig: &util.Config{Host: "host", BaseURI: "v1"},
+	}
+	invalidRegistryClient.Client = &invalidClient
+
+	testCases := []struct {
+		name                string
+		ctx                 context.Context
+		globalTrafficPolicy *v1.GlobalTrafficPolicy
+		registryClient      *registry.RegistryClient
+		expectedError       error
+	}{
+		{
+			name: "Given valid params to Updated func " +
+				"When no func returns an error " +
+				"Then the func proceed to modifySe",
+			globalTrafficPolicy: &v1.GlobalTrafficPolicy{
+				ObjectMeta: apiMachineryMetaV1.ObjectMeta{
+					Name:        "testgtp",
+					Labels:      map[string]string{"identity": "testapp"},
+					Annotations: map[string]string{"admiral.io/env": "testenv"},
+				},
+			},
+			ctx:            context.WithValue(context.Background(), "txId", "txidvalue"),
+			registryClient: validRegistryClient,
+			expectedError:  fmt.Errorf("op=Updated type=globaltrafficpolicy name=testgtp cluster=test-k8s error=task=Update name=testenv namespace=testapp cluster= message=processing skipped during cache warm up state for env=testenv identity=testapp"),
+		},
+		{
+			name: "Given valid params to Updated func " +
+				"When handleEvent func returns an error " +
+				"Then the func should return an error",
+			globalTrafficPolicy: &v1.GlobalTrafficPolicy{
+				ObjectMeta: apiMachineryMetaV1.ObjectMeta{
+					Name:        "testgtp",
+					Annotations: map[string]string{"admiral.io/env": "testenv"},
+				},
+			},
+			ctx:            context.WithValue(context.Background(), "txId", "txidvalue"),
+			registryClient: validRegistryClient,
+			expectedError:  fmt.Errorf("op=Updated type=globaltrafficpolicy name=testgtp cluster=test-k8s error=op=Event type=globaltrafficpolicy name=testgtp cluster=test-k8s message=Skipped as 'identity was not found', namespace="),
+		},
+		{
+			name: "Given valid params to Updated func " +
+				"When registry func returns an error " +
+				"Then the func should proceed",
+			globalTrafficPolicy: &v1.GlobalTrafficPolicy{
+				ObjectMeta: apiMachineryMetaV1.ObjectMeta{
+					Name:        "testgtp",
+					Labels:      map[string]string{"identity": "testapp"},
+					Annotations: map[string]string{"admiral.io/env": "testenv"},
+				},
+			},
+			ctx:            context.WithValue(context.Background(), "txId", "txidvalue"),
+			registryClient: invalidRegistryClient,
+			expectedError:  fmt.Errorf("op=Updated type=globaltrafficpolicy name=testgtp cluster=test-k8s error=task=Update name=testenv namespace=testapp cluster= message=processing skipped during cache warm up state for env=testenv identity=testapp"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			remoteRegistry.RegistryClient = tc.registryClient
+			gtpHandler := GlobalTrafficHandler{
+				RemoteRegistry: remoteRegistry,
+				ClusterID:      "test-k8s",
+			}
+			actualError := gtpHandler.Updated(tc.ctx, tc.globalTrafficPolicy)
+			if tc.expectedError != nil {
+				if actualError == nil {
+					t.Fatalf("expected error %s but got nil", tc.expectedError.Error())
+				}
+				assert.Equal(t, tc.expectedError.Error(), actualError.Error())
+			} else {
+				if actualError != nil {
+					t.Fatalf("expected error nil but got %s", actualError.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestGlobalTrafficHandler_Deleted(t *testing.T) {
+	p := common.AdmiralParams{
+		KubeconfigPath: "testdata/fake.config",
+		LabelSet: &common.LabelSet{
+			WorkloadIdentityKey:     "identity",
+			EnvKey:                  "admiral.io/env",
+			AdmiralCRDIdentityLabel: "identity",
+			PriorityKey:             "priority",
+		},
+		EnableSAN:                  true,
+		SANPrefix:                  "prefix",
+		HostnameSuffix:             "mesh",
+		SyncNamespace:              "ns",
+		CacheReconcileDuration:     10 * time.Second,
+		Profile:                    common.AdmiralProfileDefault,
+		AdmiralStateSyncerMode:     true,
+		AdmiralStateSyncerClusters: []string{"test-k8s"},
+	}
+	common.ResetSync()
+	common.InitializeConfig(p)
+	remoteRegistry, _ := InitAdmiral(context.Background(), p)
+	dummyRespBody := ioutil.NopCloser(bytes.NewBufferString("dummyRespBody"))
+	validRegistryClient := registry.NewDefaultRegistryClient()
+	validClient := test.MockClient{
+		ExpectedDeleteResponse: &http.Response{
+			StatusCode: 200,
+			Body:       dummyRespBody,
+		},
+		ExpectedDeleteErr: nil,
+		ExpectedConfig:    &util.Config{Host: "host", BaseURI: "v1"},
+	}
+	validRegistryClient.Client = &validClient
+	invalidRegistryClient := registry.NewDefaultRegistryClient()
+	invalidClient := test.MockClient{
+		ExpectedDeleteResponse: &http.Response{
+			StatusCode: 404,
+			Body:       dummyRespBody,
+		},
+		ExpectedDeleteErr: fmt.Errorf("failed private auth call"),
+		ExpectedConfig:    &util.Config{Host: "host", BaseURI: "v1"},
+	}
+	invalidRegistryClient.Client = &invalidClient
+
+	testCases := []struct {
+		name                string
+		ctx                 context.Context
+		globalTrafficPolicy *v1.GlobalTrafficPolicy
+		registryClient      *registry.RegistryClient
+		expectedError       error
+	}{
+		{
+			name: "Given valid params to Deleted func " +
+				"When no func returns an error " +
+				"Then the func proceed to modifySe",
+			globalTrafficPolicy: &v1.GlobalTrafficPolicy{
+				ObjectMeta: apiMachineryMetaV1.ObjectMeta{
+					Name:        "testgtp",
+					Labels:      map[string]string{"identity": "testapp"},
+					Annotations: map[string]string{"admiral.io/env": "testenv"},
+				},
+			},
+			ctx:            context.WithValue(context.Background(), "txId", "txidvalue"),
+			registryClient: validRegistryClient,
+			expectedError:  fmt.Errorf("op=Deleted type=globaltrafficpolicy name=testgtp cluster=test-k8s error=task=Update name=testenv namespace=testapp cluster= message=processing skipped during cache warm up state for env=testenv identity=testapp"),
+		},
+		{
+			name: "Given valid params to Updated func " +
+				"When handleEvent func returns an error " +
+				"Then the func should return an error",
+			globalTrafficPolicy: &v1.GlobalTrafficPolicy{
+				ObjectMeta: apiMachineryMetaV1.ObjectMeta{
+					Name:        "testgtp",
+					Annotations: map[string]string{"admiral.io/env": "testenv"},
+				},
+			},
+			ctx:            context.WithValue(context.Background(), "txId", "txidvalue"),
+			registryClient: validRegistryClient,
+			expectedError:  fmt.Errorf("op=Deleted type=globaltrafficpolicy name=testgtp cluster=test-k8s error=op=Event type=globaltrafficpolicy name=testgtp cluster=test-k8s message=Skipped as 'identity was not found', namespace="),
+		},
+		{
+			name: "Given valid params to Updated func " +
+				"When registry func returns an error " +
+				"Then the func should proceed",
+			globalTrafficPolicy: &v1.GlobalTrafficPolicy{
+				ObjectMeta: apiMachineryMetaV1.ObjectMeta{
+					Name:        "testgtp",
+					Labels:      map[string]string{"identity": "testapp"},
+					Annotations: map[string]string{"admiral.io/env": "testenv"},
+				},
+			},
+			ctx:            context.WithValue(context.Background(), "txId", "txidvalue"),
+			registryClient: invalidRegistryClient,
+			expectedError:  fmt.Errorf("op=Deleted type=globaltrafficpolicy name=testgtp cluster=test-k8s error=task=Update name=testenv namespace=testapp cluster= message=processing skipped during cache warm up state for env=testenv identity=testapp"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			remoteRegistry.RegistryClient = tc.registryClient
+			gtpHandler := GlobalTrafficHandler{
+				RemoteRegistry: remoteRegistry,
+				ClusterID:      "test-k8s",
+			}
+			actualError := gtpHandler.Deleted(tc.ctx, tc.globalTrafficPolicy)
+			if tc.expectedError != nil {
+				if actualError == nil {
+					t.Fatalf("expected error %s but got nil", tc.expectedError.Error())
+				}
+				assert.Equal(t, tc.expectedError.Error(), actualError.Error())
+			} else {
+				if actualError != nil {
+					t.Fatalf("expected error nil but got %s", actualError.Error())
+				}
+			}
 		})
 	}
 }

--- a/admiral/pkg/clusters/outlierdetection_handler_test.go
+++ b/admiral/pkg/clusters/outlierdetection_handler_test.go
@@ -1,8 +1,15 @@
 package clusters
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"github.com/istio-ecosystem/admiral/admiral/pkg/registry"
+	"github.com/istio-ecosystem/admiral/admiral/pkg/test"
+	"github.com/istio-ecosystem/admiral/admiral/pkg/util"
+	"io/ioutil"
+	"net/http"
 	"testing"
 
 	"github.com/istio-ecosystem/admiral/admiral/pkg/apis/admiral/model"
@@ -109,4 +116,258 @@ func TestHandleEventForOutlierDetection(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOutlierDetectionHandler_Added(t *testing.T) {
+	p := common.AdmiralParams{
+		KubeconfigPath: "testdata/fake.config",
+		LabelSet: &common.LabelSet{
+			WorkloadIdentityKey:     "identity",
+			EnvKey:                  "admiral.io/env",
+			AdmiralCRDIdentityLabel: "identity",
+			PriorityKey:             "priority",
+		},
+		Profile:                    common.AdmiralProfileDefault,
+		AdmiralStateSyncerMode:     true,
+		AdmiralStateSyncerClusters: []string{"test-k8s"},
+	}
+	common.ResetSync()
+	common.InitializeConfig(p)
+	remoteRegistry, _ := InitAdmiral(context.Background(), p)
+	validRegistryClient, invalidRegistryClient := getBasicRegistryClients()
+	od := getBasicOd()
+
+	testCases := []struct {
+		name             string
+		ctx              context.Context
+		outlierDetection *v1.OutlierDetection
+		registryClient   *registry.RegistryClient
+		expectedError    error
+	}{
+		{
+			name: "Given valid params to Added func " +
+				"When no func returns an error " +
+				"Then the func proceed to modifySe",
+			outlierDetection: od,
+			ctx:              context.WithValue(context.Background(), "txId", "txidvalue"),
+			registryClient:   validRegistryClient,
+			expectedError:    fmt.Errorf("op=Add type=OutlierDetection name= cluster=test-k8s error=skipped processing as cname is empty"),
+		},
+		{
+			name: "Given valid params to Added func " +
+				"When registryClient func returns an error " +
+				"Then the func should proceed to modifySe and return an error",
+			outlierDetection: od,
+			ctx:              context.WithValue(context.Background(), "txId", "txidvalue"),
+			registryClient:   invalidRegistryClient,
+			expectedError:    fmt.Errorf("op=Add type=OutlierDetection name= cluster=test-k8s error=skipped processing as cname is empty"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			remoteRegistry.RegistryClient = tc.registryClient
+			odHandler := OutlierDetectionHandler{
+				RemoteRegistry: remoteRegistry,
+				ClusterID:      "test-k8s",
+			}
+			actualError := odHandler.Added(tc.ctx, tc.outlierDetection)
+			if tc.expectedError != nil {
+				if actualError == nil {
+					t.Fatalf("expected error %s but got nil", tc.expectedError.Error())
+				}
+				assert.Equal(t, tc.expectedError.Error(), actualError.Error())
+			} else {
+				if actualError != nil {
+					t.Fatalf("expected error nil but got %s", actualError.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestOutlierDetectionHandler_Updated(t *testing.T) {
+	p := common.AdmiralParams{
+		KubeconfigPath: "testdata/fake.config",
+		LabelSet: &common.LabelSet{
+			WorkloadIdentityKey:     "identity",
+			EnvKey:                  "admiral.io/env",
+			AdmiralCRDIdentityLabel: "identity",
+			PriorityKey:             "priority",
+		},
+		Profile:                    common.AdmiralProfileDefault,
+		AdmiralStateSyncerMode:     true,
+		AdmiralStateSyncerClusters: []string{"test-k8s"},
+	}
+	common.ResetSync()
+	common.InitializeConfig(p)
+	remoteRegistry, _ := InitAdmiral(context.Background(), p)
+	validRegistryClient, invalidRegistryClient := getBasicRegistryClients()
+	od := getBasicOd()
+
+	testCases := []struct {
+		name             string
+		ctx              context.Context
+		outlierDetection *v1.OutlierDetection
+		registryClient   *registry.RegistryClient
+		expectedError    error
+	}{
+		{
+			name: "Given valid params to Update func " +
+				"When no func returns an error " +
+				"Then the func proceed to modifySe",
+			outlierDetection: od,
+			ctx:              context.WithValue(context.Background(), "txId", "txidvalue"),
+			registryClient:   validRegistryClient,
+			expectedError:    fmt.Errorf("op=Update type=OutlierDetection name= cluster=test-k8s error=skipped processing as cname is empty"),
+		},
+		{
+			name: "Given valid params to Update func " +
+				"When registryClient func returns an error " +
+				"Then the func should proceed to modifySe and return an error",
+			outlierDetection: od,
+			ctx:              context.WithValue(context.Background(), "txId", "txidvalue"),
+			registryClient:   invalidRegistryClient,
+			expectedError:    fmt.Errorf("op=Update type=OutlierDetection name= cluster=test-k8s error=skipped processing as cname is empty"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			remoteRegistry.RegistryClient = tc.registryClient
+			odHandler := OutlierDetectionHandler{
+				RemoteRegistry: remoteRegistry,
+				ClusterID:      "test-k8s",
+			}
+			actualError := odHandler.Updated(tc.ctx, tc.outlierDetection)
+			if tc.expectedError != nil {
+				if actualError == nil {
+					t.Fatalf("expected error %s but got nil", tc.expectedError.Error())
+				}
+				assert.Equal(t, tc.expectedError.Error(), actualError.Error())
+			} else {
+				if actualError != nil {
+					t.Fatalf("expected error nil but got %s", actualError.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestOutlierDetectionHandler_Deleted(t *testing.T) {
+	p := common.AdmiralParams{
+		KubeconfigPath: "testdata/fake.config",
+		LabelSet: &common.LabelSet{
+			WorkloadIdentityKey:     "identity",
+			EnvKey:                  "admiral.io/env",
+			AdmiralCRDIdentityLabel: "identity",
+			PriorityKey:             "priority",
+		},
+		Profile:                    common.AdmiralProfileDefault,
+		AdmiralStateSyncerMode:     true,
+		AdmiralStateSyncerClusters: []string{"test-k8s"},
+	}
+	common.ResetSync()
+	common.InitializeConfig(p)
+	remoteRegistry, _ := InitAdmiral(context.Background(), p)
+	validRegistryClient, invalidRegistryClient := getBasicRegistryClients()
+	od := getBasicOd()
+
+	testCases := []struct {
+		name             string
+		ctx              context.Context
+		outlierDetection *v1.OutlierDetection
+		registryClient   *registry.RegistryClient
+		expectedError    error
+	}{
+		{
+			name: "Given valid params to Delete func " +
+				"When no func returns an error " +
+				"Then the func proceed to modifySe",
+			outlierDetection: od,
+			ctx:              context.WithValue(context.Background(), "txId", "txidvalue"),
+			registryClient:   validRegistryClient,
+			expectedError:    fmt.Errorf("op=Delete type=OutlierDetection name= cluster=test-k8s error=skipped processing as cname is empty"),
+		},
+		{
+			name: "Given valid params to Delete func " +
+				"When registryClient func returns an error " +
+				"Then the func should proceed to modifySe and return an error",
+			outlierDetection: od,
+			ctx:              context.WithValue(context.Background(), "txId", "txidvalue"),
+			registryClient:   invalidRegistryClient,
+			expectedError:    fmt.Errorf("op=Delete type=OutlierDetection name= cluster=test-k8s error=skipped processing as cname is empty"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			remoteRegistry.RegistryClient = tc.registryClient
+			odHandler := OutlierDetectionHandler{
+				RemoteRegistry: remoteRegistry,
+				ClusterID:      "test-k8s",
+			}
+			actualError := odHandler.Deleted(tc.ctx, tc.outlierDetection)
+			if tc.expectedError != nil {
+				if actualError == nil {
+					t.Fatalf("expected error %s but got nil", tc.expectedError.Error())
+				}
+				assert.Equal(t, tc.expectedError.Error(), actualError.Error())
+			} else {
+				if actualError != nil {
+					t.Fatalf("expected error nil but got %s", actualError.Error())
+				}
+			}
+		})
+	}
+}
+
+func getBasicRegistryClients() (*registry.RegistryClient, *registry.RegistryClient) {
+	dummyRespBody := ioutil.NopCloser(bytes.NewBufferString("dummyRespBody"))
+	validRegistryClient := registry.NewDefaultRegistryClient()
+	validClient := test.MockClient{
+		ExpectedPutResponse: &http.Response{
+			StatusCode: 200,
+			Body:       dummyRespBody,
+		},
+		ExpectedPutErr: nil,
+		ExpectedConfig: &util.Config{Host: "host", BaseURI: "v1"},
+	}
+	validRegistryClient.Client = &validClient
+	invalidRegistryClient := registry.NewDefaultRegistryClient()
+	invalidClient := test.MockClient{
+		ExpectedPutResponse: &http.Response{
+			StatusCode: 404,
+			Body:       dummyRespBody,
+		},
+		ExpectedPutErr: fmt.Errorf("failed private auth call"),
+		ExpectedConfig: &util.Config{Host: "host", BaseURI: "v1"},
+	}
+	invalidRegistryClient.Client = &invalidClient
+	return validRegistryClient, invalidRegistryClient
+}
+
+func getBasicOd() *v1.OutlierDetection {
+	odConfig := model.OutlierConfig{
+		BaseEjectionTime:         0,
+		ConsecutiveGatewayErrors: 0,
+		Interval:                 0,
+		XXX_NoUnkeyedLiteral:     struct{}{},
+		XXX_unrecognized:         nil,
+		XXX_sizecache:            0,
+	}
+
+	od := &v1.OutlierDetection{
+		TypeMeta:   metaV1.TypeMeta{},
+		ObjectMeta: metaV1.ObjectMeta{},
+		Spec: model.OutlierDetection{
+			OutlierConfig:        &odConfig,
+			Selector:             map[string]string{"identity": "payments", "env": "e2e"},
+			XXX_NoUnkeyedLiteral: struct{}{},
+			XXX_unrecognized:     nil,
+			XXX_sizecache:        0,
+		},
+		Status: v1.OutlierDetectionStatus{},
+	}
+	return od
 }

--- a/admiral/pkg/clusters/outlierdetection_handler_test.go
+++ b/admiral/pkg/clusters/outlierdetection_handler_test.go
@@ -118,14 +118,12 @@ func TestHandleEventForOutlierDetection(t *testing.T) {
 	}
 }
 
-func TestOutlierDetectionHandler_Added(t *testing.T) {
+func TestCallRegistryForOutlierDetection(t *testing.T) {
 	p := common.AdmiralParams{
 		KubeconfigPath: "testdata/fake.config",
 		LabelSet: &common.LabelSet{
-			WorkloadIdentityKey:     "identity",
 			EnvKey:                  "admiral.io/env",
 			AdmiralCRDIdentityLabel: "identity",
-			PriorityKey:             "priority",
 		},
 		Profile:                    common.AdmiralProfileDefault,
 		AdmiralStateSyncerMode:     true,
@@ -134,195 +132,6 @@ func TestOutlierDetectionHandler_Added(t *testing.T) {
 	common.ResetSync()
 	common.InitializeConfig(p)
 	remoteRegistry, _ := InitAdmiral(context.Background(), p)
-	validRegistryClient, invalidRegistryClient := getBasicRegistryClients()
-	od := getBasicOd()
-
-	testCases := []struct {
-		name             string
-		ctx              context.Context
-		outlierDetection *v1.OutlierDetection
-		registryClient   *registry.RegistryClient
-		expectedError    error
-	}{
-		{
-			name: "Given valid params to Added func " +
-				"When no func returns an error " +
-				"Then the func proceed to modifySe",
-			outlierDetection: od,
-			ctx:              context.WithValue(context.Background(), "txId", "txidvalue"),
-			registryClient:   validRegistryClient,
-			expectedError:    fmt.Errorf("op=Add type=OutlierDetection name= cluster=test-k8s error=skipped processing as cname is empty"),
-		},
-		{
-			name: "Given valid params to Added func " +
-				"When registryClient func returns an error " +
-				"Then the func should proceed to modifySe and return an error",
-			outlierDetection: od,
-			ctx:              context.WithValue(context.Background(), "txId", "txidvalue"),
-			registryClient:   invalidRegistryClient,
-			expectedError:    fmt.Errorf("op=Add type=OutlierDetection name= cluster=test-k8s error=skipped processing as cname is empty"),
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			remoteRegistry.RegistryClient = tc.registryClient
-			odHandler := OutlierDetectionHandler{
-				RemoteRegistry: remoteRegistry,
-				ClusterID:      "test-k8s",
-			}
-			actualError := odHandler.Added(tc.ctx, tc.outlierDetection)
-			if tc.expectedError != nil {
-				if actualError == nil {
-					t.Fatalf("expected error %s but got nil", tc.expectedError.Error())
-				}
-				assert.Equal(t, tc.expectedError.Error(), actualError.Error())
-			} else {
-				if actualError != nil {
-					t.Fatalf("expected error nil but got %s", actualError.Error())
-				}
-			}
-		})
-	}
-}
-
-func TestOutlierDetectionHandler_Updated(t *testing.T) {
-	p := common.AdmiralParams{
-		KubeconfigPath: "testdata/fake.config",
-		LabelSet: &common.LabelSet{
-			WorkloadIdentityKey:     "identity",
-			EnvKey:                  "admiral.io/env",
-			AdmiralCRDIdentityLabel: "identity",
-			PriorityKey:             "priority",
-		},
-		Profile:                    common.AdmiralProfileDefault,
-		AdmiralStateSyncerMode:     true,
-		AdmiralStateSyncerClusters: []string{"test-k8s"},
-	}
-	common.ResetSync()
-	common.InitializeConfig(p)
-	remoteRegistry, _ := InitAdmiral(context.Background(), p)
-	validRegistryClient, invalidRegistryClient := getBasicRegistryClients()
-	od := getBasicOd()
-
-	testCases := []struct {
-		name             string
-		ctx              context.Context
-		outlierDetection *v1.OutlierDetection
-		registryClient   *registry.RegistryClient
-		expectedError    error
-	}{
-		{
-			name: "Given valid params to Update func " +
-				"When no func returns an error " +
-				"Then the func proceed to modifySe",
-			outlierDetection: od,
-			ctx:              context.WithValue(context.Background(), "txId", "txidvalue"),
-			registryClient:   validRegistryClient,
-			expectedError:    fmt.Errorf("op=Update type=OutlierDetection name= cluster=test-k8s error=skipped processing as cname is empty"),
-		},
-		{
-			name: "Given valid params to Update func " +
-				"When registryClient func returns an error " +
-				"Then the func should proceed to modifySe and return an error",
-			outlierDetection: od,
-			ctx:              context.WithValue(context.Background(), "txId", "txidvalue"),
-			registryClient:   invalidRegistryClient,
-			expectedError:    fmt.Errorf("op=Update type=OutlierDetection name= cluster=test-k8s error=skipped processing as cname is empty"),
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			remoteRegistry.RegistryClient = tc.registryClient
-			odHandler := OutlierDetectionHandler{
-				RemoteRegistry: remoteRegistry,
-				ClusterID:      "test-k8s",
-			}
-			actualError := odHandler.Updated(tc.ctx, tc.outlierDetection)
-			if tc.expectedError != nil {
-				if actualError == nil {
-					t.Fatalf("expected error %s but got nil", tc.expectedError.Error())
-				}
-				assert.Equal(t, tc.expectedError.Error(), actualError.Error())
-			} else {
-				if actualError != nil {
-					t.Fatalf("expected error nil but got %s", actualError.Error())
-				}
-			}
-		})
-	}
-}
-
-func TestOutlierDetectionHandler_Deleted(t *testing.T) {
-	p := common.AdmiralParams{
-		KubeconfigPath: "testdata/fake.config",
-		LabelSet: &common.LabelSet{
-			WorkloadIdentityKey:     "identity",
-			EnvKey:                  "admiral.io/env",
-			AdmiralCRDIdentityLabel: "identity",
-			PriorityKey:             "priority",
-		},
-		Profile:                    common.AdmiralProfileDefault,
-		AdmiralStateSyncerMode:     true,
-		AdmiralStateSyncerClusters: []string{"test-k8s"},
-	}
-	common.ResetSync()
-	common.InitializeConfig(p)
-	remoteRegistry, _ := InitAdmiral(context.Background(), p)
-	validRegistryClient, invalidRegistryClient := getBasicRegistryClients()
-	od := getBasicOd()
-
-	testCases := []struct {
-		name             string
-		ctx              context.Context
-		outlierDetection *v1.OutlierDetection
-		registryClient   *registry.RegistryClient
-		expectedError    error
-	}{
-		{
-			name: "Given valid params to Delete func " +
-				"When no func returns an error " +
-				"Then the func proceed to modifySe",
-			outlierDetection: od,
-			ctx:              context.WithValue(context.Background(), "txId", "txidvalue"),
-			registryClient:   validRegistryClient,
-			expectedError:    fmt.Errorf("op=Delete type=OutlierDetection name= cluster=test-k8s error=skipped processing as cname is empty"),
-		},
-		{
-			name: "Given valid params to Delete func " +
-				"When registryClient func returns an error " +
-				"Then the func should proceed to modifySe and return an error",
-			outlierDetection: od,
-			ctx:              context.WithValue(context.Background(), "txId", "txidvalue"),
-			registryClient:   invalidRegistryClient,
-			expectedError:    fmt.Errorf("op=Delete type=OutlierDetection name= cluster=test-k8s error=skipped processing as cname is empty"),
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			remoteRegistry.RegistryClient = tc.registryClient
-			odHandler := OutlierDetectionHandler{
-				RemoteRegistry: remoteRegistry,
-				ClusterID:      "test-k8s",
-			}
-			actualError := odHandler.Deleted(tc.ctx, tc.outlierDetection)
-			if tc.expectedError != nil {
-				if actualError == nil {
-					t.Fatalf("expected error %s but got nil", tc.expectedError.Error())
-				}
-				assert.Equal(t, tc.expectedError.Error(), actualError.Error())
-			} else {
-				if actualError != nil {
-					t.Fatalf("expected error nil but got %s", actualError.Error())
-				}
-			}
-		})
-	}
-}
-
-func getBasicRegistryClients() (*registry.RegistryClient, *registry.RegistryClient) {
 	dummyRespBody := ioutil.NopCloser(bytes.NewBufferString("dummyRespBody"))
 	validRegistryClient := registry.NewDefaultRegistryClient()
 	validClient := test.MockClient{
@@ -336,15 +145,73 @@ func getBasicRegistryClients() (*registry.RegistryClient, *registry.RegistryClie
 	validRegistryClient.Client = &validClient
 	invalidRegistryClient := registry.NewDefaultRegistryClient()
 	invalidClient := test.MockClient{
-		ExpectedPutResponse: &http.Response{
+		ExpectedDeleteResponse: &http.Response{
 			StatusCode: 404,
 			Body:       dummyRespBody,
 		},
-		ExpectedPutErr: fmt.Errorf("failed private auth call"),
-		ExpectedConfig: &util.Config{Host: "host", BaseURI: "v1"},
+		ExpectedDeleteErr: fmt.Errorf("failed private auth call"),
+		ExpectedConfig:    &util.Config{Host: "host", BaseURI: "v1"},
 	}
 	invalidRegistryClient.Client = &invalidClient
-	return validRegistryClient, invalidRegistryClient
+	od := getBasicOd()
+
+	testCases := []struct {
+		name             string
+		ctx              context.Context
+		outlierDetection *v1.OutlierDetection
+		registryClient   *registry.RegistryClient
+		event            admiral.EventType
+		expectedError    error
+	}{
+		{
+			name: "Given valid registry client " +
+				"When calling for add event " +
+				"Then error should be nil",
+			outlierDetection: od,
+			ctx:              context.WithValue(context.Background(), "txId", "txidvalue"),
+			registryClient:   validRegistryClient,
+			event:            admiral.Add,
+			expectedError:    nil,
+		},
+		{
+			name: "Given valid registry client " +
+				"When calling for update event " +
+				"Then error should be nil",
+			outlierDetection: od,
+			ctx:              context.WithValue(context.Background(), "txId", "txidvalue"),
+			registryClient:   validRegistryClient,
+			event:            admiral.Update,
+			expectedError:    nil,
+		},
+		{
+			name: "Given valid params to call registry func " +
+				"When registry func returns an error " +
+				"Then handler should receive an error",
+			outlierDetection: od,
+			ctx:              context.WithValue(context.Background(), "txId", "txidvalue"),
+			registryClient:   invalidRegistryClient,
+			event:            admiral.Delete,
+			expectedError:    fmt.Errorf("op=Delete type=OutlierDetection name= cluster=test-k8s message=failed to Delete OutlierDetection with err: failed private auth call"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			remoteRegistry.RegistryClient = tc.registryClient
+			clusterName := "test-k8s"
+			actualError := callRegistryForOutlierDetection(tc.ctx, tc.event, remoteRegistry, clusterName, tc.outlierDetection)
+			if tc.expectedError != nil {
+				if actualError == nil {
+					t.Fatalf("expected error %s but got nil", tc.expectedError.Error())
+				}
+				assert.Equal(t, tc.expectedError.Error(), actualError.Error())
+			} else {
+				if actualError != nil {
+					t.Fatalf("expected error nil but got %s", actualError.Error())
+				}
+			}
+		})
+	}
 }
 
 func getBasicOd() *v1.OutlierDetection {

--- a/admiral/pkg/clusters/rollout_handler_test.go
+++ b/admiral/pkg/clusters/rollout_handler_test.go
@@ -190,11 +190,13 @@ func newFakeRollout(name, namespace string, matchLabels map[string]string) *argo
 		ObjectMeta: metaV1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Labels:    map[string]string{"identity": name},
 		},
 		Spec: argo.RolloutSpec{
 			Selector: &metaV1.LabelSelector{
 				MatchLabels: matchLabels,
 			},
+			Template: coreV1.PodTemplateSpec{ObjectMeta: metaV1.ObjectMeta{Labels: map[string]string{"identity": name}}},
 		},
 	}
 }

--- a/admiral/pkg/clusters/service_handler.go
+++ b/admiral/pkg/clusters/service_handler.go
@@ -144,7 +144,6 @@ func handleServiceEventForDeployment(
 			}
 		}
 
-		// Why are we deleting the svc and then adding it back in case of delete?
 		if common.IsAdmiralStateSyncerMode() && common.IsStateSyncerCluster(clusterName) {
 			if common.GetDeploymentGlobalIdentifier(&deployment) != "" {
 				err := remoteRegistry.RegistryClient.PutHostingData(clusterName, svc.Namespace, svc.Name, common.GetDeploymentGlobalIdentifier(&deployment), "service", ctx.Value("txId").(string), svc)

--- a/admiral/pkg/clusters/virtualservice_handler.go
+++ b/admiral/pkg/clusters/virtualservice_handler.go
@@ -82,6 +82,12 @@ func (vh *VirtualServiceHandler) Added(ctx context.Context, obj *v1alpha3.Virtua
 	if IgnoreIstioResource(obj.Spec.ExportTo, obj.Annotations, obj.Namespace) {
 		return nil
 	}
+	if common.IsAdmiralStateSyncerMode() && common.IsStateSyncerCluster(vh.clusterID) {
+		err := vh.remoteRegistry.RegistryClient.PutCustomData(vh.clusterID, obj.Namespace, obj.Name, "VirtualService", ctx.Value("txId").(string), obj)
+		if err != nil {
+			log.Errorf(LogFormat, common.Add, "VirtualService", obj.Name, vh.clusterID, "failed to update VirtualService custom data")
+		}
+	}
 	return vh.handleVirtualServiceEvent(ctx, obj, common.Add)
 }
 
@@ -91,6 +97,12 @@ func (vh *VirtualServiceHandler) Updated(ctx context.Context, obj *v1alpha3.Virt
 	}
 	if IgnoreIstioResource(obj.Spec.ExportTo, obj.Annotations, obj.Namespace) {
 		return nil
+	}
+	if common.IsAdmiralStateSyncerMode() && common.IsStateSyncerCluster(vh.clusterID) {
+		err := vh.remoteRegistry.RegistryClient.PutCustomData(vh.clusterID, obj.Namespace, obj.Name, "VirtualService", ctx.Value("txId").(string), obj)
+		if err != nil {
+			log.Errorf(LogFormat, common.Update, "VirtualService", obj.Name, vh.clusterID, "failed to update VirtualService custom data")
+		}
 	}
 	return vh.handleVirtualServiceEvent(ctx, obj, common.Update)
 }
@@ -106,6 +118,12 @@ func (vh *VirtualServiceHandler) Deleted(ctx context.Context, obj *v1alpha3.Virt
 			log.Debugf(LogFormat, "admiralIoIgnoreAnnotationCheck", "VirtualService", obj.Name, vh.clusterID, "Value=true namespace="+obj.Namespace)
 		}
 		return nil
+	}
+	if common.IsAdmiralStateSyncerMode() && common.IsStateSyncerCluster(vh.clusterID) {
+		err := vh.remoteRegistry.RegistryClient.DeleteCustomData(vh.clusterID, obj.Namespace, obj.Name, "VirtualService", ctx.Value("txId").(string))
+		if err != nil {
+			log.Errorf(LogFormat, common.Delete, "VirtualService", obj.Name, vh.clusterID, "failed to delete VirtualService custom data")
+		}
 	}
 	return vh.handleVirtualServiceEvent(ctx, obj, common.Delete)
 }

--- a/admiral/pkg/controller/common/config_test.go
+++ b/admiral/pkg/controller/common/config_test.go
@@ -740,6 +740,38 @@ func TestGetCRDIdentityLabelWithCRDIdentity(t *testing.T) {
 	admiralParams.LabelSet.AdmiralCRDIdentityLabel = backOldIdentity
 }
 
+func TestSetArgoRolloutsEnabled(t *testing.T) {
+	p := AdmiralParams{}
+	p.ArgoRolloutsEnabled = true
+	ResetSync()
+	InitializeConfig(p)
+
+	SetArgoRolloutsEnabled(true)
+	assert.Equal(t, true, GetArgoRolloutsEnabled())
+}
+
+func TestSetCartographerFeature(t *testing.T) {
+	p := AdmiralParams{}
+	ResetSync()
+	InitializeConfig(p)
+
+	SetCartographerFeature("feature", "enabled")
+	assert.Equal(t, "enabled", wrapper.params.CartographerFeatures["feature"])
+}
+
+func TestGetResyncIntervals(t *testing.T) {
+	p := AdmiralParams{}
+	p.CacheReconcileDuration = time.Minute
+	p.SeAndDrCacheReconcileDuration = time.Minute
+	ResetSync()
+	InitializeConfig(p)
+
+	actual := GetResyncIntervals()
+
+	assert.Equal(t, time.Minute, actual.SeAndDrReconcileInterval)
+	assert.Equal(t, time.Minute, actual.UniversalReconcileInterval)
+}
+
 //func TestGetCRDIdentityLabelWithLabel(t *testing.T) {
 //
 //	admiralParams := GetAdmiralParams()


### PR DESCRIPTION
Calls registry from the handler functions to push info

Observations - inner source has a lot of extra log lines in the handler functions. pkg/clusters/types has references to idps client that need to be added in the inner source commit, and the idps client and resolvers need to be updated in the inner source commit as well.