### PR TITLE
vs routing initial commit

### DIFF
--- a/admiral/pkg/clusters/destinationrule_handler.go
+++ b/admiral/pkg/clusters/destinationrule_handler.go
@@ -459,7 +459,7 @@ func addUpdateDestinationRule(
 	// 1. Through modifyse, in which case obj will already have exportTo filled and we don't want to do a repeat call of getSortedDependentNamespaces
 	// 2. Through the flow where we copy customer created DRs to other clusters, in which case it shouldn't have exportTo set and we need to calculate it here.
 	if common.EnableExportTo(obj.Spec.Host) && len(obj.Spec.ExportTo) == 0 {
-		sortedDependentNamespaces := getSortedDependentNamespaces(rr.AdmiralCache, obj.Spec.Host, rc.ClusterID, ctxLogger)
+		sortedDependentNamespaces := getSortedDependentNamespaces(rr.AdmiralCache, obj.Spec.Host, rc.ClusterID, ctxLogger, false)
 		obj.Spec.ExportTo = sortedDependentNamespaces
 	}
 	drIsNew := exist == nil || exist.Name == "" || exist.Spec.Host == ""

--- a/admiral/pkg/clusters/destinationrule_handler.go
+++ b/admiral/pkg/clusters/destinationrule_handler.go
@@ -454,11 +454,20 @@ func addUpdateDestinationRule(
 		obj.Annotations = map[string]string{}
 	}
 	obj.Annotations["app.kubernetes.io/created-by"] = "admiral"
+
+	//Check if DR has the admiral.io/vs-routing label
+	// If it does, skip adding ExportTo since it is already set to "istio-system" only
+	// The DR created for routing cross cluster traffic should only be exported to istio-system
+	skipAddingExportTo := false
+	if obj.Labels != nil && obj.Labels[vsRoutingLabel] == "enabled" {
+		skipAddingExportTo = true
+	}
+
 	// At this step we check to make sure the DR does not already have an exportTo value before setting the exportTo value
 	// This is because there are two ways to enter this function
 	// 1. Through modifyse, in which case obj will already have exportTo filled and we don't want to do a repeat call of getSortedDependentNamespaces
 	// 2. Through the flow where we copy customer created DRs to other clusters, in which case it shouldn't have exportTo set and we need to calculate it here.
-	if common.EnableExportTo(obj.Spec.Host) && len(obj.Spec.ExportTo) == 0 {
+	if common.EnableExportTo(obj.Spec.Host) && len(obj.Spec.ExportTo) == 0 && !skipAddingExportTo {
 		sortedDependentNamespaces := getSortedDependentNamespaces(rr.AdmiralCache, obj.Spec.Host, rc.ClusterID, ctxLogger, false)
 		obj.Spec.ExportTo = sortedDependentNamespaces
 	}

--- a/admiral/pkg/clusters/serviceentry.go
+++ b/admiral/pkg/clusters/serviceentry.go
@@ -847,14 +847,15 @@ func modifyServiceEntryForNewServiceOrPod(
 			deploymentOrRolloutName, namespace, "", err)
 		modifySEerr = common.AppendError(modifySEerr, err)
 	} else {
-		err := addUpdateDestinationRuleForSourceIngress(
+		err := addUpdateInClusterDestinationRule(
 			ctx,
 			ctxLogger,
 			remoteRegistry,
 			sourceClusterToDRHosts,
-			sourceIdentity)
+			sourceIdentity,
+			cname)
 		if err != nil {
-			ctxLogger.Errorf(common.CtxLogFormat, "addUpdateDestinationRuleForSourceIngress",
+			ctxLogger.Errorf(common.CtxLogFormat, "addUpdateInClusterDestinationRule",
 				deploymentOrRolloutName, namespace, "", err)
 			modifySEerr = common.AppendError(modifySEerr, err)
 		}
@@ -2171,7 +2172,7 @@ func createAdditionalEndpoints(
 	}
 
 	err = addUpdateVirtualService(
-		ctxLogger, ctx, virtualService, existingVS, namespace, rc, rr, virtualService.Spec.Hosts[0], false)
+		ctxLogger, ctx, virtualService, existingVS, namespace, rc, rr, virtualService.Spec.Hosts[0])
 	if err != nil {
 		return fmt.Errorf("failed generating additional endpoints from serviceentry due to error: %w", err)
 	}

--- a/admiral/pkg/clusters/serviceentry.go
+++ b/admiral/pkg/clusters/serviceentry.go
@@ -2172,7 +2172,7 @@ func createAdditionalEndpoints(
 	}
 
 	err = addUpdateVirtualService(
-		ctxLogger, ctx, virtualService, existingVS, namespace, rc, rr, virtualService.Spec.Hosts[0])
+		ctxLogger, ctx, virtualService, existingVS, namespace, rc, rr)
 	if err != nil {
 		return fmt.Errorf("failed generating additional endpoints from serviceentry due to error: %w", err)
 	}

--- a/admiral/pkg/clusters/serviceentry.go
+++ b/admiral/pkg/clusters/serviceentry.go
@@ -2166,11 +2166,6 @@ func createAdditionalEndpoints(
 	}
 	virtualService.Annotations = vsAnnotations
 
-	if len(virtualService.Spec.Hosts) == 0 {
-		return fmt.Errorf(
-			"failed generating additional endpoints since no virtual service contained no hosts")
-	}
-
 	err = addUpdateVirtualService(
 		ctxLogger, ctx, virtualService, existingVS, namespace, rc, rr)
 	if err != nil {

--- a/admiral/pkg/clusters/util.go
+++ b/admiral/pkg/clusters/util.go
@@ -220,7 +220,13 @@ func filterClusters(sourceClusters, destinationClusters *common.Map) *common.Map
 // Then, it fetches the dependent namespaces based on the cname or cnameWithoutPrefix and adds them to the list of dependent namespaces
 // If the list is above the maximum number of allowed exportTo values, it replaces the entries with "*"
 // Otherwise, it sorts and dedups the list of dependent namespaces and returns them.
-func getSortedDependentNamespaces(admiralCache *AdmiralCache, cname string, clusterId string, ctxLogger *logrus.Entry) []string {
+func getSortedDependentNamespaces(
+	admiralCache *AdmiralCache,
+	cname string,
+	clusterId string,
+	ctxLogger *logrus.Entry,
+	skipIstioNSFromExportTo bool) []string {
+
 	var clusterNamespaces *common.MapOfMaps
 	var namespaceSlice []string
 	var cnameWithoutPrefix string
@@ -241,7 +247,9 @@ func getSortedDependentNamespaces(admiralCache *AdmiralCache, cname string, clus
 		if ok && admiralCache.IdentityClusterCache != nil {
 			sourceClusters := admiralCache.IdentityClusterCache.Get(partitionedIdentity.(string))
 			if sourceClusters != nil && sourceClusters.Get(clusterId) != "" {
-				namespaceSlice = append(namespaceSlice, common.NamespaceIstioSystem)
+				if !skipIstioNSFromExportTo {
+					namespaceSlice = append(namespaceSlice, common.NamespaceIstioSystem)
+				}
 
 				// Add source namespaces s.t. throttle filter can query envoy clusters
 				if admiralCache.IdentityClusterNamespaceCache != nil && admiralCache.IdentityClusterNamespaceCache.Get(partitionedIdentity.(string)) != nil {

--- a/admiral/pkg/clusters/util.go
+++ b/admiral/pkg/clusters/util.go
@@ -247,9 +247,7 @@ func getSortedDependentNamespaces(
 		if ok && admiralCache.IdentityClusterCache != nil {
 			sourceClusters := admiralCache.IdentityClusterCache.Get(partitionedIdentity.(string))
 			if sourceClusters != nil && sourceClusters.Get(clusterId) != "" {
-				if !skipIstioNSFromExportTo {
-					namespaceSlice = append(namespaceSlice, common.NamespaceIstioSystem)
-				}
+				namespaceSlice = append(namespaceSlice, common.NamespaceIstioSystem)
 
 				// Add source namespaces s.t. throttle filter can query envoy clusters
 				if admiralCache.IdentityClusterNamespaceCache != nil && admiralCache.IdentityClusterNamespaceCache.Get(partitionedIdentity.(string)) != nil {
@@ -285,6 +283,9 @@ func getSortedDependentNamespaces(
 	var dedupNamespaceSlice []string
 	for i := 0; i < len(namespaceSlice); i++ {
 		if i == 0 || namespaceSlice[i] != namespaceSlice[i-1] {
+			if skipIstioNSFromExportTo && namespaceSlice[i] == common.NamespaceIstioSystem {
+				continue
+			}
 			dedupNamespaceSlice = append(dedupNamespaceSlice, namespaceSlice[i])
 		}
 	}

--- a/admiral/pkg/clusters/util.go
+++ b/admiral/pkg/clusters/util.go
@@ -247,7 +247,9 @@ func getSortedDependentNamespaces(
 		if ok && admiralCache.IdentityClusterCache != nil {
 			sourceClusters := admiralCache.IdentityClusterCache.Get(partitionedIdentity.(string))
 			if sourceClusters != nil && sourceClusters.Get(clusterId) != "" {
-				namespaceSlice = append(namespaceSlice, common.NamespaceIstioSystem)
+				if skipIstioNSFromExportTo {
+					namespaceSlice = append(namespaceSlice, common.NamespaceIstioSystem)
+				}
 
 				// Add source namespaces s.t. throttle filter can query envoy clusters
 				if admiralCache.IdentityClusterNamespaceCache != nil && admiralCache.IdentityClusterNamespaceCache.Get(partitionedIdentity.(string)) != nil {
@@ -283,9 +285,6 @@ func getSortedDependentNamespaces(
 	var dedupNamespaceSlice []string
 	for i := 0; i < len(namespaceSlice); i++ {
 		if i == 0 || namespaceSlice[i] != namespaceSlice[i-1] {
-			if skipIstioNSFromExportTo && namespaceSlice[i] == common.NamespaceIstioSystem {
-				continue
-			}
 			dedupNamespaceSlice = append(dedupNamespaceSlice, namespaceSlice[i])
 		}
 	}

--- a/admiral/pkg/clusters/util.go
+++ b/admiral/pkg/clusters/util.go
@@ -247,7 +247,7 @@ func getSortedDependentNamespaces(
 		if ok && admiralCache.IdentityClusterCache != nil {
 			sourceClusters := admiralCache.IdentityClusterCache.Get(partitionedIdentity.(string))
 			if sourceClusters != nil && sourceClusters.Get(clusterId) != "" {
-				if skipIstioNSFromExportTo {
+				if !skipIstioNSFromExportTo {
 					namespaceSlice = append(namespaceSlice, common.NamespaceIstioSystem)
 				}
 

--- a/admiral/pkg/clusters/util_test.go
+++ b/admiral/pkg/clusters/util_test.go
@@ -1023,6 +1023,7 @@ func TestGetSortedDependentNamespaces(t *testing.T) {
 		cnameDependentClusterNamespaceCache *common.MapOfMapOfMaps
 		cname                               string
 		clusterId                           string
+		skipIstioNSFromExportTo             bool
 		expectedResult                      []string
 	}{
 		{
@@ -1125,6 +1126,18 @@ func TestGetSortedDependentNamespaces(t *testing.T) {
 			clusterId:                           "cluster3",
 			expectedResult:                      []string{"*"},
 		},
+		{
+			name: "Given the cname has dependent cluster namespaces and some dependents in the source cluster " +
+				"And we skip adding istio-system NS to the exportTo list" +
+				"Then we should return a sorted slice of the dependent cluster namespaces excluding istio-system",
+			identityClusterCache:                idclustercache,
+			cnameIdentityCache:                  cnameidcache,
+			cnameDependentClusterNamespaceCache: cndepclusternscache,
+			cname:                               "cname",
+			clusterId:                           "cluster2",
+			skipIstioNSFromExportTo:             true,
+			expectedResult:                      []string{"ns1", "ns2"},
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -1132,7 +1145,8 @@ func TestGetSortedDependentNamespaces(t *testing.T) {
 			admiralCache.IdentityClusterCache = c.identityClusterCache
 			admiralCache.CnameIdentityCache = c.cnameIdentityCache
 			admiralCache.CnameDependentClusterNamespaceCache = c.cnameDependentClusterNamespaceCache
-			result := getSortedDependentNamespaces(admiralCache, c.cname, c.clusterId, ctxLogger)
+			result := getSortedDependentNamespaces(
+				admiralCache, c.cname, c.clusterId, ctxLogger, c.skipIstioNSFromExportTo)
 			if !reflect.DeepEqual(result, c.expectedResult) {
 				t.Errorf("expected: %v, got: %v", c.expectedResult, result)
 			}
@@ -1216,4 +1230,3 @@ func TestGetDestinationsToBeProcessedForClientInitiatedProcessing(t *testing.T) 
 		})
 	}
 }
-

--- a/admiral/pkg/clusters/virtualservice_handler.go
+++ b/admiral/pkg/clusters/virtualservice_handler.go
@@ -359,11 +359,6 @@ func syncVirtualServiceToDependentCluster(
 		}
 	}
 
-	if len(virtualService.Spec.Hosts) == 0 {
-		return fmt.Errorf(
-			"VirtualService %s has no hosts, cannot sync to dependent clusters", virtualService.Name)
-	}
-
 	// nolint
 	err = addUpdateVirtualService(ctxLogger, ctx, virtualService, exist, syncNamespace, rc, remoteRegistry)
 
@@ -471,11 +466,6 @@ func syncVirtualServiceToRemoteCluster(
 	if isDeadCluster(err) {
 		ctxLogger.Warnf(LogErrFormat, "Create/Update", common.VirtualServiceResourceType, vSName, cluster, "dead cluster")
 		return nil
-	}
-
-	if len(virtualService.Spec.Hosts) == 0 {
-		return fmt.Errorf(
-			"VirtualService %s has no hosts, cannot sync to dependent clusters", virtualService.Name)
 	}
 
 	err = addUpdateVirtualService(ctxLogger, ctx, virtualService, exist, syncNamespace, rc, remoteRegistry)

--- a/admiral/pkg/clusters/virtualservice_handler.go
+++ b/admiral/pkg/clusters/virtualservice_handler.go
@@ -365,8 +365,7 @@ func syncVirtualServiceToDependentCluster(
 	}
 
 	// nolint
-	err = addUpdateVirtualService(
-		ctxLogger, ctx, virtualService, exist, syncNamespace, rc, remoteRegistry, virtualService.Spec.Hosts[0])
+	err = addUpdateVirtualService(ctxLogger, ctx, virtualService, exist, syncNamespace, rc, remoteRegistry)
 
 	// Best effort delete for existing virtual service with old name
 	_ = rc.VirtualServiceController.IstioClient.NetworkingV1alpha3().VirtualServices(syncNamespace).Delete(ctx, oldVSname, metav1.DeleteOptions{})
@@ -479,8 +478,7 @@ func syncVirtualServiceToRemoteCluster(
 			"VirtualService %s has no hosts, cannot sync to dependent clusters", virtualService.Name)
 	}
 
-	err = addUpdateVirtualService(
-		ctxLogger, ctx, virtualService, exist, syncNamespace, rc, remoteRegistry, virtualService.Spec.Hosts[0])
+	err = addUpdateVirtualService(ctxLogger, ctx, virtualService, exist, syncNamespace, rc, remoteRegistry)
 
 	// Best effort delete of existing virtual service with old name
 	_ = rc.VirtualServiceController.IstioClient.NetworkingV1alpha3().VirtualServices(syncNamespace).Delete(ctx, oldVSname, metav1.DeleteOptions{})
@@ -508,9 +506,7 @@ func addUpdateVirtualService(
 	new *v1alpha3.VirtualService,
 	exist *v1alpha3.VirtualService,
 	namespace string,
-	rc *RemoteController,
-	rr *RemoteRegistry,
-	cname string) error {
+	rc *RemoteController, rr *RemoteRegistry) error {
 	var (
 		err     error
 		op      string
@@ -540,7 +536,7 @@ func addUpdateVirtualService(
 
 	if common.EnableExportTo(newCopy.Spec.Hosts[0]) && !skipAddingExportTo {
 		sortedDependentNamespaces := getSortedDependentNamespaces(
-			rr.AdmiralCache, cname, rc.ClusterID, ctxLogger, false)
+			rr.AdmiralCache, newCopy.Spec.Hosts[0], rc.ClusterID, ctxLogger, false)
 		newCopy.Spec.ExportTo = sortedDependentNamespaces
 		ctxLogger.Infof(LogFormat, "ExportTo", common.VirtualServiceResourceType, newCopy.Name, rc.ClusterID, fmt.Sprintf("VS usecase-ExportTo updated to %v", newCopy.Spec.ExportTo))
 	}

--- a/admiral/pkg/clusters/virtualservice_handler_test.go
+++ b/admiral/pkg/clusters/virtualservice_handler_test.go
@@ -1822,7 +1822,7 @@ func TestAddUpdateVirtualService(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			addUpdateVirtualService(ctxLogger, ctx, c.newVS, c.existingVS, namespace, rc, rr)
+			addUpdateVirtualService(ctxLogger, ctx, c.newVS, c.existingVS, namespace, rc, rr, c.newVS.Spec.Hosts[0], false)
 			vs, err := istioClientWithExistingVS.NetworkingV1alpha3().VirtualServices(namespace).Get(ctx, fooVS.Name, metaV1.GetOptions{})
 			if err != nil {
 				t.Errorf("failed to get VS with error: %v", err)

--- a/admiral/pkg/clusters/virtualservice_handler_test.go
+++ b/admiral/pkg/clusters/virtualservice_handler_test.go
@@ -1822,7 +1822,7 @@ func TestAddUpdateVirtualService(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			addUpdateVirtualService(ctxLogger, ctx, c.newVS, c.existingVS, namespace, rc, rr, c.newVS.Spec.Hosts[0])
+			addUpdateVirtualService(ctxLogger, ctx, c.newVS, c.existingVS, namespace, rc, rr)
 			vs, err := istioClientWithExistingVS.NetworkingV1alpha3().VirtualServices(namespace).Get(ctx, fooVS.Name, metaV1.GetOptions{})
 			if err != nil {
 				t.Errorf("failed to get VS with error: %v", err)

--- a/admiral/pkg/clusters/virtualservice_handler_test.go
+++ b/admiral/pkg/clusters/virtualservice_handler_test.go
@@ -1822,7 +1822,7 @@ func TestAddUpdateVirtualService(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			addUpdateVirtualService(ctxLogger, ctx, c.newVS, c.existingVS, namespace, rc, rr, c.newVS.Spec.Hosts[0], false)
+			addUpdateVirtualService(ctxLogger, ctx, c.newVS, c.existingVS, namespace, rc, rr, c.newVS.Spec.Hosts[0])
 			vs, err := istioClientWithExistingVS.NetworkingV1alpha3().VirtualServices(namespace).Get(ctx, fooVS.Name, metaV1.GetOptions{})
 			if err != nil {
 				t.Errorf("failed to get VS with error: %v", err)

--- a/admiral/pkg/clusters/virtualservice_routing.go
+++ b/admiral/pkg/clusters/virtualservice_routing.go
@@ -656,7 +656,7 @@ func addUpdateInClusterVirtualServices(
 		ctxLogger.Infof(common.CtxLogFormat, "addUpdateInClusterVirtualServices",
 			virtualService.Name, virtualService.Namespace, sourceCluster, "Add/Update ingress virtualservice")
 		err = addUpdateVirtualService(
-			ctxLogger, ctx, virtualService, existingVS, util.IstioSystemNamespace, rc, remoteRegistry, vsName)
+			ctxLogger, ctx, virtualService, existingVS, util.IstioSystemNamespace, rc, remoteRegistry)
 		if err != nil {
 			ctxLogger.Errorf(common.CtxLogFormat, "addUpdateInClusterVirtualServices",
 				virtualService.Name, virtualService.Namespace, sourceCluster, err.Error())
@@ -724,7 +724,7 @@ func addUpdateVirtualServicesForIngress(
 		ctxLogger.Infof(common.CtxLogFormat, "addUpdateVirtualServicesForIngress",
 			virtualService.Name, virtualService.Namespace, sourceCluster, "Add/Update ingress virtualservice")
 		err = addUpdateVirtualService(
-			ctxLogger, ctx, virtualService, existingVS, util.IstioSystemNamespace, rc, remoteRegistry, vsName)
+			ctxLogger, ctx, virtualService, existingVS, util.IstioSystemNamespace, rc, remoteRegistry)
 		if err != nil {
 			ctxLogger.Errorf(common.CtxLogFormat, "addUpdateVirtualServicesForIngress",
 				virtualService.Name, virtualService.Namespace, sourceCluster, err.Error())

--- a/admiral/pkg/clusters/virtualservice_routing.go
+++ b/admiral/pkg/clusters/virtualservice_routing.go
@@ -21,6 +21,16 @@ import (
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// getBaseInClusterVirtualService generates the base in-cluster virtual service
+func getBaseInClusterVirtualService() (*v1alpha3.VirtualService, error) {
+	return &v1alpha3.VirtualService{
+		ObjectMeta: metaV1.ObjectMeta{
+			Namespace: util.IstioSystemNamespace,
+		},
+		Spec: networkingV1Alpha3.VirtualService{},
+	}, nil
+}
+
 // getBaseVirtualServiceForIngress generates the base virtual service for the ingress gateway
 // This is just the barebones of the ingress virtual service
 func getBaseVirtualServiceForIngress() (*v1alpha3.VirtualService, error) {
@@ -449,6 +459,204 @@ func populateDestinationsForCanaryStrategy(
 	return nil
 }
 
+// generateVirtualServiceForIncluster generates the VirtualService for the in-cluster routing
+func generateVirtualServiceForIncluster(
+	destination map[string][]*vsrouting.RouteDestination,
+	vsName string) (*v1alpha3.VirtualService, error) {
+
+	virtualService, err := getBaseInClusterVirtualService()
+	if err != nil {
+		return nil, err
+	}
+
+	vsHosts := make([]string, 0)
+	httpRoutes := make([]*networkingV1Alpha3.HTTPRoute, 0)
+
+	for globalFQDN, routeDestinations := range destination {
+		if routeDestinations == nil || len(routeDestinations) == 0 {
+			continue
+		}
+		fqdn, err := getFQDNFromSNIHost(globalFQDN)
+		if err != nil {
+			continue
+		}
+		httpRoute := networkingV1Alpha3.HTTPRoute{
+			Match: []*networkingV1Alpha3.HTTPMatchRequest{
+				{
+					Authority: &networkingV1Alpha3.StringMatch{
+						MatchType: &networkingV1Alpha3.StringMatch_Prefix{
+							Prefix: fqdn,
+						},
+					},
+				},
+			},
+		}
+		httpRouteDestinations := make([]*networkingV1Alpha3.HTTPRouteDestination, 0)
+		for _, routeDestination := range routeDestinations {
+			httpRouteDestinations = append(httpRouteDestinations, routeDestination.ToHTTPRouteDestination())
+		}
+		httpRoute.Route = httpRouteDestinations
+		httpRoutes = append(httpRoutes, &httpRoute)
+		vsHosts = append(vsHosts, fqdn)
+	}
+
+	if len(vsHosts) == 0 {
+		return nil, fmt.Errorf(
+			"skipped creating virtualservice as there are no valid hosts found")
+	}
+	if len(httpRoutes) == 0 {
+		return nil, fmt.Errorf(
+			"skipped creating virtualservice on cluster as there are no valid http routes found")
+	}
+	sort.Strings(vsHosts)
+	virtualService.Spec.Hosts = vsHosts
+	sort.Slice(httpRoutes, func(i, j int) bool {
+		return httpRoutes[i].Match[0].Authority.String() < httpRoutes[j].Match[0].Authority.String()
+	})
+	virtualService.Spec.Http = httpRoutes
+
+	virtualService.Name = vsName + "-incluster-vs"
+
+	return virtualService, nil
+
+}
+
+// generateVirtualServiceForIngress generates the VirtualService for the cross-cluster routing
+func generateVirtualServiceForIngress(
+	destination map[string][]*vsrouting.RouteDestination,
+	vsName string) (*v1alpha3.VirtualService, error) {
+
+	virtualService, err := getBaseVirtualServiceForIngress()
+	if err != nil {
+		return nil, err
+	}
+
+	vsHosts := make([]string, 0)
+	tlsRoutes := make([]*networkingV1Alpha3.TLSRoute, 0)
+
+	for globalFQDN, routeDestinations := range destination {
+		if routeDestinations == nil || len(routeDestinations) == 0 {
+			continue
+		}
+		tlsRoute := networkingV1Alpha3.TLSRoute{
+			Match: []*networkingV1Alpha3.TLSMatchAttributes{
+				{
+					Port:     common.DefaultMtlsPort,
+					SniHosts: []string{globalFQDN},
+				},
+			},
+		}
+		tlsRouteDestinations := make([]*networkingV1Alpha3.RouteDestination, 0)
+		for _, routeDestination := range routeDestinations {
+			tlsRouteDestinations = append(tlsRouteDestinations, routeDestination.ToTLSRouteDestination())
+		}
+		tlsRoute.Route = tlsRouteDestinations
+		tlsRoutes = append(tlsRoutes, &tlsRoute)
+		vsHosts = append(vsHosts, globalFQDN)
+	}
+
+	if len(vsHosts) == 0 {
+		return nil, fmt.Errorf(
+			"skipped creating virtualservice as there are no valid hosts found")
+	}
+	if len(tlsRoutes) == 0 {
+		return nil, fmt.Errorf(
+			"skipped creating virtualservice on cluster as there are no valid tls routes found")
+	}
+	sort.Strings(vsHosts)
+	virtualService.Spec.Hosts = vsHosts
+	sort.Slice(tlsRoutes, func(i, j int) bool {
+		return tlsRoutes[i].Match[0].SniHosts[0] < tlsRoutes[j].Match[0].SniHosts[0]
+	})
+	virtualService.Spec.Tls = tlsRoutes
+
+	virtualService.Name = vsName + "-routing-vs"
+
+	return virtualService, nil
+}
+
+// addUpdateInClusterVirtualServices adds or updates the in-cluster routing VirtualServices
+// This is where the VirtualServices are created using the services that were discovered during the
+// discovery phase.
+func addUpdateInClusterVirtualServices(
+	ctx context.Context,
+	ctxLogger *log.Entry,
+	remoteRegistry *RemoteRegistry,
+	sourceClusterToDestinations map[string]map[string][]*vsrouting.RouteDestination,
+	vsName string,
+	sourceIdentity string) error {
+
+	if sourceIdentity == "" {
+		return fmt.Errorf("identity is empty")
+	}
+
+	if !common.DoVSRoutingInClusterForIdentity(sourceIdentity) {
+		ctxLogger.Infof(common.CtxLogFormat, "VSBasedRoutingInCluster",
+			"", "", "",
+			fmt.Sprintf(
+				"Writing phase: addUpdateInClusterVirtualServices VS based routing disabled for identity %s",
+				sourceIdentity))
+		return nil
+	}
+
+	if remoteRegistry == nil {
+		return fmt.Errorf("remoteRegistry is nil")
+	}
+
+	if vsName == "" {
+		return fmt.Errorf("vsName is empty")
+	}
+
+	for sourceCluster, destination := range sourceClusterToDestinations {
+
+		if !common.DoVSRoutingInClusterForCluster(sourceCluster) {
+			ctxLogger.Infof(common.CtxLogFormat, "VSBasedRoutingInCluster",
+				"", "", sourceCluster,
+				"Writing phase: addUpdateInClusterVirtualServices VS based routing disabled for cluster")
+			continue
+		}
+
+		ctxLogger.Debugf(common.CtxLogFormat, "VSBasedRoutingInCluster",
+			"", "", sourceCluster,
+			"Writing phase: addUpdateInClusterVirtualServices VS based routing enabled for cluster")
+
+		rc := remoteRegistry.GetRemoteController(sourceCluster)
+
+		if rc == nil {
+			ctxLogger.Warnf(common.CtxLogFormat, "addUpdateInClusterVirtualServices",
+				"", "", sourceCluster, "remote controller not initialized on this cluster")
+			continue
+		}
+
+		virtualService, err := generateVirtualServiceForIncluster(destination, vsName)
+		if err != nil {
+			ctxLogger.Errorf(common.CtxLogFormat, "addUpdateInClusterVirtualServices",
+				"", "", sourceCluster, err.Error())
+			return err
+		}
+
+		existingVS, err := getExistingVS(ctxLogger, ctx, rc, virtualService.Name, util.IstioSystemNamespace)
+		if err != nil {
+			ctxLogger.Warn(common.CtxLogFormat, "addUpdateInClusterVirtualServices",
+				virtualService.Name, virtualService.Namespace, sourceCluster, err.Error())
+		}
+
+		ctxLogger.Infof(common.CtxLogFormat, "addUpdateInClusterVirtualServices",
+			virtualService.Name, virtualService.Namespace, sourceCluster, "Add/Update ingress virtualservice")
+		err = addUpdateVirtualService(
+			ctxLogger, ctx, virtualService, existingVS, util.IstioSystemNamespace, rc, remoteRegistry, vsName, true)
+		if err != nil {
+			ctxLogger.Errorf(common.CtxLogFormat, "addUpdateInClusterVirtualServices",
+				virtualService.Name, virtualService.Namespace, sourceCluster, err.Error())
+			return err
+		}
+		ctxLogger.Infof(common.CtxLogFormat, "addUpdateInClusterVirtualServices",
+			virtualService.Name, virtualService.Namespace, sourceCluster, "virtualservice created successfully")
+	}
+
+	return nil
+}
+
 // addUpdateVirtualServicesForSourceIngress adds or updates the cross-cluster routing VirtualServices
 // This is where the VirtualServices are created using the services that were discovered during the
 // discovery phase.
@@ -488,62 +696,12 @@ func addUpdateVirtualServicesForIngress(
 			continue
 		}
 
-		virtualService, err := getBaseVirtualServiceForIngress()
+		virtualService, err := generateVirtualServiceForIngress(destination, vsName)
 		if err != nil {
 			ctxLogger.Errorf(common.CtxLogFormat, "addUpdateVirtualServicesForIngress",
-				vsName, util.IstioSystemNamespace, sourceCluster, err.Error())
+				"", "", sourceCluster, err.Error())
 			return err
 		}
-
-		vsHosts := make([]string, 0)
-		tlsRoutes := make([]*networkingV1Alpha3.TLSRoute, 0)
-
-		for globalFQDN, routeDestinations := range destination {
-			if routeDestinations == nil || len(routeDestinations) == 0 {
-				ctxLogger.Warnf(common.CtxLogFormat, "addUpdateVirtualServicesForIngress",
-					"", "", sourceCluster,
-					fmt.Sprintf("skipped adding host %s, no valid route destinaton found", globalFQDN))
-				continue
-			}
-			tlsRoute := networkingV1Alpha3.TLSRoute{
-				Match: []*networkingV1Alpha3.TLSMatchAttributes{
-					{
-						Port:     common.DefaultMtlsPort,
-						SniHosts: []string{globalFQDN},
-					},
-				},
-			}
-			tlsRouteDestinations := make([]*networkingV1Alpha3.RouteDestination, 0)
-			for _, routeDestination := range routeDestinations {
-				tlsRouteDestinations = append(tlsRouteDestinations, routeDestination.ToTLSRouteDestination())
-			}
-			tlsRoute.Route = tlsRouteDestinations
-			tlsRoutes = append(tlsRoutes, &tlsRoute)
-			vsHosts = append(vsHosts, globalFQDN)
-		}
-
-		if len(vsHosts) == 0 {
-			err := fmt.Errorf(
-				"skipped creating virtualservice on cluster %s, no valid hosts found", sourceCluster)
-			ctxLogger.Errorf(common.CtxLogFormat, "addUpdateVirtualServicesForIngress",
-				virtualService.Name, virtualService.Namespace, sourceCluster, err.Error())
-			return err
-		}
-		if len(tlsRoutes) == 0 {
-			err := fmt.Errorf(
-				"skipped creating virtualservice on cluster %s, no valid tls routes found", sourceCluster)
-			ctxLogger.Errorf(common.CtxLogFormat, "addUpdateVirtualServicesForIngress",
-				virtualService.Name, virtualService.Namespace, sourceCluster, err.Error())
-			return err
-		}
-		sort.Strings(vsHosts)
-		virtualService.Spec.Hosts = vsHosts
-		sort.Slice(tlsRoutes, func(i, j int) bool {
-			return tlsRoutes[i].Match[0].SniHosts[0] < tlsRoutes[j].Match[0].SniHosts[0]
-		})
-		virtualService.Spec.Tls = tlsRoutes
-
-		virtualService.Name = vsName + "-routing-vs"
 
 		existingVS, err := getExistingVS(ctxLogger, ctx, rc, virtualService.Name, util.IstioSystemNamespace)
 		if err != nil {
@@ -554,7 +712,7 @@ func addUpdateVirtualServicesForIngress(
 		ctxLogger.Infof(common.CtxLogFormat, "addUpdateVirtualServicesForIngress",
 			virtualService.Name, virtualService.Namespace, sourceCluster, "Add/Update ingress virtualservice")
 		err = addUpdateVirtualService(
-			ctxLogger, ctx, virtualService, existingVS, util.IstioSystemNamespace, rc, remoteRegistry)
+			ctxLogger, ctx, virtualService, existingVS, util.IstioSystemNamespace, rc, remoteRegistry, vsName, true)
 		if err != nil {
 			ctxLogger.Errorf(common.CtxLogFormat, "addUpdateVirtualServicesForIngress",
 				virtualService.Name, virtualService.Namespace, sourceCluster, err.Error())

--- a/admiral/pkg/clusters/virtualservice_routing_test.go
+++ b/admiral/pkg/clusters/virtualservice_routing_test.go
@@ -25,6 +25,514 @@ import (
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func TestAddUpdateInClusterVirtualServices(t *testing.T) {
+
+	existingVS := &apiNetworkingV1Alpha3.VirtualService{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:      "test-env.test-identity.global-incluster-vs",
+			Namespace: util.IstioSystemNamespace,
+		},
+		Spec: networkingV1Alpha3.VirtualService{
+			Hosts:    []string{"test-env.test-identity.global"},
+			ExportTo: []string{"istio-system"},
+			Http: []*networkingV1Alpha3.HTTPRoute{
+				{
+					Match: []*networkingV1Alpha3.HTTPMatchRequest{
+						{
+							Authority: &networkingV1Alpha3.StringMatch{
+								MatchType: &networkingV1Alpha3.StringMatch_Prefix{
+									Prefix: "test-env.test-identity.global",
+								},
+							},
+						},
+					},
+					Route: []*networkingV1Alpha3.HTTPRouteDestination{
+						{
+							Destination: &networkingV1Alpha3.Destination{
+								Host: "test-rollout-svc.test-ns.svc.cluster.local",
+								Port: &networkingV1Alpha3.PortSelector{
+									Number: 8080,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	admiralParams := common.AdmiralParams{
+		LabelSet:                            &common.LabelSet{},
+		EnableSWAwareNSCaches:               true,
+		EnableVSRoutingInCluster:            true,
+		VSRoutingInClusterEnabledIdentities: []string{"test-identity"},
+		VSRoutingInClusterEnabledClusters:   []string{"cluster-1"},
+	}
+	common.ResetSync()
+	common.InitializeConfig(admiralParams)
+
+	istioClientWithExistingVS := istioFake.NewSimpleClientset()
+	istioClientWithExistingVS.NetworkingV1alpha3().VirtualServices(util.IstioSystemNamespace).
+		Create(context.Background(), existingVS, metaV1.CreateOptions{})
+
+	istioClientWithNoExistingVS := istioFake.NewSimpleClientset()
+	rc := &RemoteController{
+		ClusterID:                "cluster-1",
+		VirtualServiceController: &istio.VirtualServiceController{},
+	}
+
+	rr := NewRemoteRegistry(context.Background(), admiralParams)
+	rr.PutRemoteController("cluster-1", rc)
+
+	rr.AdmiralCache.CnameIdentityCache = &sync.Map{}
+	rr.AdmiralCache.CnameIdentityCache.Store("test-env.test-identity.global", "test-identity")
+
+	rr.AdmiralCache.IdentityClusterCache = common.NewMapOfMaps()
+	rr.AdmiralCache.IdentityClusterCache.Put("test-identity", "cluster-1", "cluster-1")
+
+	rr.AdmiralCache.IdentityClusterCache = common.NewMapOfMaps()
+	rr.AdmiralCache.IdentityClusterNamespaceCache.Put(
+		"test-identity", "cluster-1", "test-dependent-ns0", "test-dependent-ns0")
+	rr.AdmiralCache.IdentityClusterNamespaceCache.Put(
+		"test-identity", "cluster-1", "test-dependent-ns1", "test-dependent-ns1")
+
+	rr.AdmiralCache.CnameDependentClusterNamespaceCache = common.NewMapOfMapOfMaps()
+	rr.AdmiralCache.CnameDependentClusterNamespaceCache.Put(
+		"test-env.test-identity.global", "cluster-1", "test-ns", "test-ns")
+
+	defaultFQDN := "test-env.test-identity.global"
+	previewFQDN := "preview.test-env.test-identity.global"
+	canaryFQDN := "canary.test-env.test-identity.global"
+
+	sourceDestinationsWithSingleDestinationSvc := map[string]map[string][]*vsrouting.RouteDestination{
+		"cluster-1": {
+			defaultFQDN: {
+				{
+					Destination: &networkingV1Alpha3.Destination{
+						Host: "test-deployment-svc.test-ns.svc.cluster.local",
+						Port: &networkingV1Alpha3.PortSelector{
+							Number: 8080,
+						},
+					},
+				},
+			},
+		},
+	}
+	sourceDestinationsWithPreviewSvc := map[string]map[string][]*vsrouting.RouteDestination{
+		"cluster-1": {
+			defaultFQDN: {
+				{
+					Destination: &networkingV1Alpha3.Destination{
+						Host: "test-rollout-active-svc.test-ns.svc.cluster.local",
+						Port: &networkingV1Alpha3.PortSelector{
+							Number: 8080,
+						},
+					},
+				},
+			},
+			previewFQDN: {
+				{
+					Destination: &networkingV1Alpha3.Destination{
+						Host: "test-rollout-preview-svc.test-ns.svc.cluster.local",
+						Port: &networkingV1Alpha3.PortSelector{
+							Number: 8080,
+						},
+					},
+				},
+			},
+		},
+	}
+	sourceDestinationsWithCanarySvc := map[string]map[string][]*vsrouting.RouteDestination{
+		"cluster-1": {
+			defaultFQDN: {
+				{
+					Destination: &networkingV1Alpha3.Destination{
+						Host: "test-rollout-stable-svc.test-ns.svc.cluster.local",
+						Port: &networkingV1Alpha3.PortSelector{
+							Number: 8080,
+						},
+					},
+					Weight: 90,
+				},
+				{
+					Destination: &networkingV1Alpha3.Destination{
+						Host: "test-rollout-desired-svc.test-ns.svc.cluster.local",
+						Port: &networkingV1Alpha3.PortSelector{
+							Number: 8080,
+						},
+					},
+					Weight: 10,
+				},
+			},
+			canaryFQDN: {
+				{
+					Destination: &networkingV1Alpha3.Destination{
+						Host: "test-rollout-desired-svc.test-ns.svc.cluster.local",
+						Port: &networkingV1Alpha3.PortSelector{
+							Number: 8080,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctxLogger := log.WithFields(log.Fields{
+		"type": "VirtualService",
+	})
+
+	testCases := []struct {
+		name                        string
+		remoteRegistry              *RemoteRegistry
+		vsName                      string
+		sourceClusterToDestinations map[string]map[string][]*vsrouting.RouteDestination
+		istioClient                 *istioFake.Clientset
+		sourceIdentity              string
+		expectedError               error
+		expectedVS                  *apiNetworkingV1Alpha3.VirtualService
+	}{
+		{
+			name: "Given a empty sourceIdentity, " +
+				"When addUpdateInClusterVirtualServices is invoked, " +
+				"Then it should return an error",
+			sourceClusterToDestinations: sourceDestinationsWithSingleDestinationSvc,
+			expectedError:               fmt.Errorf("identity is empty"),
+		},
+		{
+			name: "Given a nil remoteRegistry, " +
+				"When addUpdateInClusterVirtualServices is invoked, " +
+				"Then it should return an error",
+			sourceIdentity:              "test-identity",
+			sourceClusterToDestinations: sourceDestinationsWithSingleDestinationSvc,
+			expectedError:               fmt.Errorf("remoteRegistry is nil"),
+		},
+		{
+			name: "Given a empty vsName, " +
+				"When addUpdateInClusterVirtualServices is invoked, " +
+				"Then it should return an error",
+			sourceIdentity:              "test-identity",
+			remoteRegistry:              rr,
+			sourceClusterToDestinations: sourceDestinationsWithSingleDestinationSvc,
+			expectedError:               fmt.Errorf("vsName is empty"),
+		},
+		{
+			name: "Given a valid sourceClusterToDestinations " +
+				"And the VS is a new VS" +
+				"When addUpdateInClusterVirtualServices is invoked, " +
+				"Then it should successfully create the VS",
+			sourceIdentity:              "test-identity",
+			remoteRegistry:              rr,
+			vsName:                      "test-env.test-identity.global",
+			istioClient:                 istioClientWithNoExistingVS,
+			sourceClusterToDestinations: sourceDestinationsWithSingleDestinationSvc,
+			expectedError:               nil,
+			expectedVS: &apiNetworkingV1Alpha3.VirtualService{
+				ObjectMeta: metaV1.ObjectMeta{
+					Name:      "test-env.test-identity.global-incluster-vs",
+					Namespace: util.IstioSystemNamespace,
+				},
+				Spec: networkingV1Alpha3.VirtualService{
+					Hosts:    []string{"test-env.test-identity.global"},
+					ExportTo: []string{"test-ns", "test-dependent-ns0", "test-dependent-ns1"},
+					Http: []*networkingV1Alpha3.HTTPRoute{
+						{
+							Match: []*networkingV1Alpha3.HTTPMatchRequest{
+								{
+									Authority: &networkingV1Alpha3.StringMatch{
+										MatchType: &networkingV1Alpha3.StringMatch_Prefix{
+											Prefix: "test-env.test-identity.global",
+										},
+									},
+								},
+							},
+							Route: []*networkingV1Alpha3.HTTPRouteDestination{
+								{
+									Destination: &networkingV1Alpha3.Destination{
+										Host: "test-deployment-svc.test-ns.svc.cluster.local",
+										Port: &networkingV1Alpha3.PortSelector{
+											Number: 8080,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Given a valid sourceClusterToDestination " +
+				"And there is VS with same name already exists" +
+				"When addUpdateInClusterVirtualServices is invoked, " +
+				"Then it should successfully update the VS",
+			sourceIdentity:              "test-identity",
+			remoteRegistry:              rr,
+			vsName:                      "test-env.test-identity.global",
+			istioClient:                 istioClientWithExistingVS,
+			sourceClusterToDestinations: sourceDestinationsWithSingleDestinationSvc,
+			expectedError:               nil,
+			expectedVS: &apiNetworkingV1Alpha3.VirtualService{
+				ObjectMeta: metaV1.ObjectMeta{
+					Name:      "test-env.test-identity.global-routing-vs",
+					Namespace: util.IstioSystemNamespace,
+				},
+				Spec: networkingV1Alpha3.VirtualService{
+					Hosts:    []string{"test-env.test-identity.global"},
+					ExportTo: []string{"test-ns", "test-dependent-ns0", "test-dependent-ns1"},
+					Http: []*networkingV1Alpha3.HTTPRoute{
+						{
+							Match: []*networkingV1Alpha3.HTTPMatchRequest{
+								{
+									Authority: &networkingV1Alpha3.StringMatch{
+										MatchType: &networkingV1Alpha3.StringMatch_Prefix{
+											Prefix: "test-env.test-identity.global",
+										},
+									},
+								},
+							},
+							Route: []*networkingV1Alpha3.HTTPRouteDestination{
+								{
+									Destination: &networkingV1Alpha3.Destination{
+										Host: "test-deployment-svc.test-ns.svc.cluster.local",
+										Port: &networkingV1Alpha3.PortSelector{
+											Number: 8080,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Given a valid sourceClusterToDestination " +
+				"And there is a preview endpoint in the sourceIngressVirtualService" +
+				"When addUpdateInClusterVirtualServices is invoked, " +
+				"Then it should successfully create a VS including the preview endpoint route",
+			sourceIdentity:              "test-identity",
+			remoteRegistry:              rr,
+			vsName:                      "test-env.test-identity.global",
+			istioClient:                 istioClientWithNoExistingVS,
+			sourceClusterToDestinations: sourceDestinationsWithPreviewSvc,
+			expectedError:               nil,
+			expectedVS: &apiNetworkingV1Alpha3.VirtualService{
+				ObjectMeta: metaV1.ObjectMeta{
+					Name:      "test-env.test-identity.global-routing-vs",
+					Namespace: util.IstioSystemNamespace,
+				},
+				Spec: networkingV1Alpha3.VirtualService{
+					Hosts: []string{
+						"preview.test-env.test-identity.global",
+						"test-env.test-identity.global",
+					},
+					ExportTo: []string{"test-ns", "test-dependent-ns0", "test-dependent-ns1"},
+					Http: []*networkingV1Alpha3.HTTPRoute{
+						{
+							Match: []*networkingV1Alpha3.HTTPMatchRequest{
+								{
+									Authority: &networkingV1Alpha3.StringMatch{
+										MatchType: &networkingV1Alpha3.StringMatch_Prefix{
+											Prefix: "preview.test-env.test-identity.global",
+										},
+									},
+								},
+							},
+							Route: []*networkingV1Alpha3.HTTPRouteDestination{
+								{
+									Destination: &networkingV1Alpha3.Destination{
+										Host: "test-rollout-preview-svc.test-ns.svc.cluster.local",
+										Port: &networkingV1Alpha3.PortSelector{
+											Number: 8080,
+										},
+									},
+								},
+							},
+						},
+						{
+							Match: []*networkingV1Alpha3.HTTPMatchRequest{
+								{
+									Authority: &networkingV1Alpha3.StringMatch{
+										MatchType: &networkingV1Alpha3.StringMatch_Prefix{
+											Prefix: "test-env.test-identity.global",
+										},
+									},
+								},
+							},
+							Route: []*networkingV1Alpha3.HTTPRouteDestination{
+								{
+									Destination: &networkingV1Alpha3.Destination{
+										Host: "test-rollout-active-svc.test-ns.svc.cluster.local",
+										Port: &networkingV1Alpha3.PortSelector{
+											Number: 8080,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Given a valid sourceClusterToDestination " +
+				"And there is a canary endpoint" +
+				"When addUpdateInClusterVirtualServices is invoked, " +
+				"Then it should successfully create a VS including the canary endpoint routes with weights",
+			sourceIdentity:              "test-identity",
+			remoteRegistry:              rr,
+			vsName:                      "test-env.test-identity.global",
+			istioClient:                 istioClientWithNoExistingVS,
+			sourceClusterToDestinations: sourceDestinationsWithCanarySvc,
+			expectedError:               nil,
+			expectedVS: &apiNetworkingV1Alpha3.VirtualService{
+				ObjectMeta: metaV1.ObjectMeta{
+					Name:      "test-env.test-identity.global-routing-vs",
+					Namespace: util.IstioSystemNamespace,
+				},
+				Spec: networkingV1Alpha3.VirtualService{
+					Hosts: []string{
+						"canary.test-env.test-identity.global",
+						"test-env.test-identity.global",
+					},
+					ExportTo: []string{"test-ns", "test-dependent-ns0", "test-dependent-ns1"},
+					Http: []*networkingV1Alpha3.HTTPRoute{
+						{
+							Match: []*networkingV1Alpha3.HTTPMatchRequest{
+								{
+									Authority: &networkingV1Alpha3.StringMatch{
+										MatchType: &networkingV1Alpha3.StringMatch_Prefix{
+											Prefix: "canary.test-env.test-identity.global",
+										},
+									},
+								},
+							},
+							Route: []*networkingV1Alpha3.HTTPRouteDestination{
+								{
+									Destination: &networkingV1Alpha3.Destination{
+										Host: "test-rollout-desired-svc.test-ns.svc.cluster.local",
+										Port: &networkingV1Alpha3.PortSelector{
+											Number: 8080,
+										},
+									},
+								},
+							},
+						},
+						{
+							Match: []*networkingV1Alpha3.HTTPMatchRequest{
+								{
+									Authority: &networkingV1Alpha3.StringMatch{
+										MatchType: &networkingV1Alpha3.StringMatch_Prefix{
+											Prefix: "test-env.test-identity.global",
+										},
+									},
+								},
+							},
+							Route: []*networkingV1Alpha3.HTTPRouteDestination{
+								{
+									Destination: &networkingV1Alpha3.Destination{
+										Host: "test-rollout-stable-svc.test-ns.svc.cluster.local",
+										Port: &networkingV1Alpha3.PortSelector{
+											Number: 8080,
+										},
+									},
+									Weight: 90,
+								},
+								{
+									Destination: &networkingV1Alpha3.Destination{
+										Host: "test-rollout-desired-svc.test-ns.svc.cluster.local",
+										Port: &networkingV1Alpha3.PortSelector{
+											Number: 8080,
+										},
+									},
+									Weight: 10,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Given a valid sourceClusterToDestination " +
+				"And there is a preview endpoint match in the VS but there is no corresponding svc found" +
+				"When addUpdateInClusterVirtualServices is invoked, " +
+				"Then the VS created should not have the preview match in the VS",
+			sourceIdentity:              "test-identity",
+			remoteRegistry:              rr,
+			vsName:                      "test-env.test-identity.global",
+			istioClient:                 istioClientWithNoExistingVS,
+			sourceClusterToDestinations: sourceDestinationsWithSingleDestinationSvc,
+			expectedError:               nil,
+			expectedVS: &apiNetworkingV1Alpha3.VirtualService{
+				ObjectMeta: metaV1.ObjectMeta{
+					Name:      "test-env.test-identity.global-routing-vs",
+					Namespace: util.IstioSystemNamespace,
+				},
+				Spec: networkingV1Alpha3.VirtualService{
+					Hosts:    []string{"test-env.test-identity.global"},
+					ExportTo: []string{"test-ns", "test-dependent-ns0", "test-dependent-ns1"},
+					Http: []*networkingV1Alpha3.HTTPRoute{
+						{
+							Match: []*networkingV1Alpha3.HTTPMatchRequest{
+								{
+									Authority: &networkingV1Alpha3.StringMatch{
+										MatchType: &networkingV1Alpha3.StringMatch_Prefix{
+											Prefix: "test-env.test-identity.global",
+										},
+									},
+								},
+							},
+							Route: []*networkingV1Alpha3.HTTPRouteDestination{
+								{
+									Destination: &networkingV1Alpha3.Destination{
+										Host: "test-deployment-svc.test-ns.svc.cluster.local",
+										Port: &networkingV1Alpha3.PortSelector{
+											Number: 8080,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rc := rr.GetRemoteController("cluster-1")
+			rc.VirtualServiceController.IstioClient = tc.istioClient
+			rr.PutRemoteController("cluster-1", rc)
+			err := addUpdateInClusterVirtualServices(
+				context.Background(),
+				ctxLogger,
+				tc.remoteRegistry,
+				tc.sourceClusterToDestinations,
+				tc.vsName,
+				tc.sourceIdentity)
+			if tc.expectedError != nil {
+				require.NotNil(t, err)
+				require.Equal(t, tc.expectedError.Error(), err.Error())
+			} else {
+				require.Nil(t, err)
+				actualVS, err := tc.istioClient.
+					NetworkingV1alpha3().
+					VirtualServices(util.IstioSystemNamespace).
+					Get(context.Background(), "test-env.test-identity.global-routing-vs", metaV1.GetOptions{})
+				require.Nil(t, err)
+				require.Equal(t, tc.expectedVS.ObjectMeta.Name, actualVS.ObjectMeta.Name)
+				require.Equal(t, tc.expectedVS.Spec.Tls, actualVS.Spec.Tls)
+				require.Equal(t, tc.expectedVS.Spec.ExportTo, actualVS.Spec.ExportTo)
+				require.Equal(t, tc.expectedVS.Spec.Gateways, actualVS.Spec.Gateways)
+				require.Equal(t, tc.expectedVS.Spec.Hosts, actualVS.Spec.Hosts)
+			}
+		})
+	}
+
+}
+
 func TestAddUpdateVirtualServicesForIngress(t *testing.T) {
 
 	vsLabels := map[string]string{


### PR DESCRIPTION
Implemented VS and DR for in-cluster VS Based Routing

```
apiVersion: networking.istio.io/v1beta1
kind: VirtualService
metadata:
  annotations:
    app.kubernetes.io/created-by: admiral
  creationTimestamp: "2025-02-25T21:23:49Z"
  generation: 2
  labels:
    admiral.io/vs-routing: enabled
  name: stage.greeting.global-incluster-vs
  namespace: istio-system
  resourceVersion: "14399"
  uid: 9e16f96e-9276-400b-a5a4-48032200599d
spec:
  exportTo:
  - sample
  hosts:
  - stage.greeting.global
  http:
  - match:
    - authority:
        prefix: stage.greeting.global
    route:
    - destination:
        host: greeting.sample.svc.cluster.local
        port:
          number: 80
```

```
apiVersion: networking.istio.io/v1beta1
kind: DestinationRule
metadata:
  annotations:
    app.kubernetes.io/created-by: admiral
  creationTimestamp: "2025-02-25T21:23:49Z"
  generation: 8
  labels:
    admiral.io/vs-routing: enabled
  name: sample.svc.cluster.local-incluster-dr
  namespace: istio-system
  resourceVersion: "14402"
  uid: 4dcab84a-c19f-433a-aa60-ab7d5b651398
spec:
  exportTo:
  - sample
  host: '*.sample.svc.cluster.local'
  trafficPolicy:
    loadBalancer:
      localityLbSetting:
        enabled: false
      simple: ROUND_ROBIN
      warmupDurationSecs: 45s
    tls:
      mode: ISTIO_MUTUAL
      subjectAltNames:
      - spiffe:///webapp
```