### PR TITLE
Refactor vs routing code

### DIFF
--- a/admiral/pkg/clusters/virtualservice_routing.go
+++ b/admiral/pkg/clusters/virtualservice_routing.go
@@ -190,7 +190,7 @@ func getRouteDestination(host string, port uint32, weight int32) *vsrouting.Rout
 //
 // Example:
 //
-// "outbound_.80_._.stage.greeting.global" ->
+// "stage.greeting.global" ->
 //
 //	 route:
 //	- destination:
@@ -239,7 +239,7 @@ func populateVSRouteDestinationForDeployment(
 //     port:
 //     number: 80
 //
-// "outbound_.80_._.preview.stage.greeting.global" ->
+// "preview.stage.greeting.global" ->
 //
 // route:
 //   - destination:
@@ -249,7 +249,7 @@ func populateVSRouteDestinationForDeployment(
 //
 // Example Canary:
 //
-// "outbound_.80_._.stage.greeting.global" ->
+// "stage.greeting.global" ->
 //
 //		route:
 //		- destination:
@@ -263,7 +263,7 @@ func populateVSRouteDestinationForDeployment(
 //		      number: 80
 //	     weight: 90
 //
-// "outbound_.80_._.canary.stage.greeting.global" ->
+// "canary.stage.greeting.global" ->
 //
 //	route:
 //	- destination:

--- a/admiral/pkg/clusters/virtualservice_routing.go
+++ b/admiral/pkg/clusters/virtualservice_routing.go
@@ -485,6 +485,7 @@ func generateVirtualServiceForIncluster(
 					},
 				},
 			},
+			Name: globalFQDN,
 		}
 		httpRouteDestinations := make([]*networkingV1Alpha3.HTTPRouteDestination, 0)
 		for _, routeDestination := range routeDestinations {

--- a/admiral/pkg/clusters/virtualservice_routing_test.go
+++ b/admiral/pkg/clusters/virtualservice_routing_test.go
@@ -102,9 +102,9 @@ func TestAddUpdateInClusterVirtualServices(t *testing.T) {
 	rr.AdmiralCache.CnameDependentClusterNamespaceCache.Put(
 		"test-env.test-identity.global", "cluster-1", "test-dependent-ns1", "test-dependent-ns1")
 
-	defaultFQDN := "outbound_.80_._.test-env.test-identity.global"
-	previewFQDN := "outbound_.80_._.preview.test-env.test-identity.global"
-	canaryFQDN := "outbound_.80_._.canary.test-env.test-identity.global"
+	defaultFQDN := "test-env.test-identity.global"
+	previewFQDN := "preview.test-env.test-identity.global"
+	canaryFQDN := "canary.test-env.test-identity.global"
 
 	sourceDestinationsWithSingleDestinationSvc := map[string]map[string][]*vsrouting.RouteDestination{
 		"cluster-1": {
@@ -596,9 +596,9 @@ func TestAddUpdateVirtualServicesForIngress(t *testing.T) {
 	rr := NewRemoteRegistry(context.Background(), admiralParams)
 	rr.PutRemoteController("cluster-1", rc)
 
-	defaultFQDN := "outbound_.80_._.test-env.test-identity.global"
-	previewFQDN := "outbound_.80_._.preview.test-env.test-identity.global"
-	canaryFQDN := "outbound_.80_._.canary.test-env.test-identity.global"
+	defaultFQDN := "test-env.test-identity.global"
+	previewFQDN := "preview.test-env.test-identity.global"
+	canaryFQDN := "canary.test-env.test-identity.global"
 
 	sourceDestinationsWithSingleDestinationSvc := map[string]map[string][]*vsrouting.RouteDestination{
 		"cluster-1": {
@@ -2731,7 +2731,7 @@ func TestProcessGTPAndAddWeightsByCluster(t *testing.T) {
 
 }
 
-func TestGetDefaultSNIHostFromDeployment(t *testing.T) {
+func TestGetDefaultFQDNFromDeployment(t *testing.T) {
 
 	admiralParams := common.AdmiralParams{
 		LabelSet: &common.LabelSet{
@@ -2780,13 +2780,13 @@ func TestGetDefaultSNIHostFromDeployment(t *testing.T) {
 				},
 			},
 			expectedError:   nil,
-			expectedSNIHost: "outbound_.80_._.test-env.test-identity.global",
+			expectedSNIHost: "test-env.test-identity.global",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := getDefaultSNIHostFromDeployment(tc.deployment)
+			actual, err := getDefaultFQDNFromDeployment(tc.deployment)
 			if tc.expectedError != nil {
 				require.NotNil(t, err)
 				require.Equal(t, tc.expectedError.Error(), err.Error())
@@ -2799,7 +2799,7 @@ func TestGetDefaultSNIHostFromDeployment(t *testing.T) {
 
 }
 
-func TestGetDefaultSNIHostFromRollout(t *testing.T) {
+func TestGetDefaultFQDNFromRollout(t *testing.T) {
 
 	admiralParams := common.AdmiralParams{
 		LabelSet: &common.LabelSet{
@@ -2854,13 +2854,13 @@ func TestGetDefaultSNIHostFromRollout(t *testing.T) {
 				},
 			},
 			expectedError:   nil,
-			expectedSNIHost: "outbound_.80_._.test-env.test-identity.global",
+			expectedSNIHost: "test-env.test-identity.global",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := getDefaultSNIHostFromRollout(tc.rollout)
+			actual, err := getDefaultFQDNFromRollout(tc.rollout)
 			if tc.expectedError != nil {
 				require.NotNil(t, err)
 				require.Equal(t, tc.expectedError.Error(), err.Error())
@@ -2873,7 +2873,7 @@ func TestGetDefaultSNIHostFromRollout(t *testing.T) {
 
 }
 
-func TestGetCanarySNIHostFromRollout(t *testing.T) {
+func TestGetCanaryFQDNFromRollout(t *testing.T) {
 
 	admiralParams := common.AdmiralParams{
 		LabelSet: &common.LabelSet{
@@ -2931,13 +2931,13 @@ func TestGetCanarySNIHostFromRollout(t *testing.T) {
 				},
 			},
 			expectedError:   nil,
-			expectedSNIHost: "outbound_.80_._.canary.test-env.test-identity.global",
+			expectedSNIHost: "canary.test-env.test-identity.global",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := getCanarySNIHostFromRollout(tc.rollout)
+			actual, err := getCanaryFQDNFromRollout(tc.rollout)
 			if tc.expectedError != nil {
 				require.NotNil(t, err)
 				require.Equal(t, tc.expectedError.Error(), err.Error())
@@ -2950,7 +2950,7 @@ func TestGetCanarySNIHostFromRollout(t *testing.T) {
 
 }
 
-func TestGetPreviewSNIHostFromRollout(t *testing.T) {
+func TestGetPreviewFQDNFromRollout(t *testing.T) {
 
 	admiralParams := common.AdmiralParams{
 		LabelSet: &common.LabelSet{
@@ -3005,13 +3005,13 @@ func TestGetPreviewSNIHostFromRollout(t *testing.T) {
 				},
 			},
 			expectedError:   nil,
-			expectedSNIHost: "outbound_.80_._.preview.test-env.test-identity.global",
+			expectedSNIHost: "preview.test-env.test-identity.global",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := getPreviewSNIHostFromRollout(tc.rollout)
+			actual, err := getPreviewFQDNFromRollout(tc.rollout)
 			if tc.expectedError != nil {
 				require.NotNil(t, err)
 				require.Equal(t, tc.expectedError.Error(), err.Error())
@@ -3626,7 +3626,7 @@ func TestGetDestinationsForGTPDNSPrefixes(t *testing.T) {
 				"Then it should return an empty gtpRouteDestinations",
 			gtp: &v1alpha12.GlobalTrafficPolicy{},
 			routeDestination: map[string][]*vsrouting.RouteDestination{
-				"outbound_.80_._.test-env.test-identity.global": nil,
+				"test-env.test-identity.global": nil,
 			},
 			expectedError:               nil,
 			expectedGTPRouteDestination: make(map[string][]*vsrouting.RouteDestination),
@@ -3698,7 +3698,7 @@ func TestGetDestinationsForGTPDNSPrefixes(t *testing.T) {
 			},
 			sourceClusterLocality: "us-west-2",
 			routeDestination: map[string][]*vsrouting.RouteDestination{
-				"outbound_.80_._.test-env.test-identity.global": {
+				"test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "active-svc.test-ns.svc.cluster.local",
@@ -3708,7 +3708,7 @@ func TestGetDestinationsForGTPDNSPrefixes(t *testing.T) {
 						},
 					},
 				},
-				"outbound_.80_._.preview.test-env.test-identity.global": {
+				"preview.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "preview-svc.test-ns.svc.cluster.local",
@@ -3718,7 +3718,7 @@ func TestGetDestinationsForGTPDNSPrefixes(t *testing.T) {
 						},
 					},
 				},
-				"outbound_.80_._.canary.test-env.test-identity.global": {
+				"canary.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "desired-svc.test-ns.svc.cluster.local",
@@ -3731,7 +3731,7 @@ func TestGetDestinationsForGTPDNSPrefixes(t *testing.T) {
 			},
 			expectedError: nil,
 			expectedGTPRouteDestination: map[string][]*vsrouting.RouteDestination{
-				"outbound_.80_._.east.test-env.test-identity.global": {
+				"east.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "active-svc.test-ns.svc.cluster.local",
@@ -3741,7 +3741,7 @@ func TestGetDestinationsForGTPDNSPrefixes(t *testing.T) {
 						},
 					},
 				},
-				"outbound_.80_._.west.test-env.test-identity.global": {
+				"west.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "active-svc.test-ns.svc.cluster.local",
@@ -3751,7 +3751,7 @@ func TestGetDestinationsForGTPDNSPrefixes(t *testing.T) {
 						},
 					},
 				},
-				"outbound_.80_._.east.canary.test-env.test-identity.global": {
+				"east.canary.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "desired-svc.test-ns.svc.cluster.local",
@@ -3761,7 +3761,7 @@ func TestGetDestinationsForGTPDNSPrefixes(t *testing.T) {
 						},
 					},
 				},
-				"outbound_.80_._.west.canary.test-env.test-identity.global": {
+				"west.canary.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "desired-svc.test-ns.svc.cluster.local",
@@ -3771,7 +3771,7 @@ func TestGetDestinationsForGTPDNSPrefixes(t *testing.T) {
 						},
 					},
 				},
-				"outbound_.80_._.test-failover.test-env.test-identity.global": {
+				"test-failover.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "active-svc.test-ns.svc.cluster.local",
@@ -3781,7 +3781,7 @@ func TestGetDestinationsForGTPDNSPrefixes(t *testing.T) {
 						},
 					},
 				},
-				"outbound_.80_._.test-failover.canary.test-env.test-identity.global": {
+				"test-failover.canary.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "desired-svc.test-ns.svc.cluster.local",
@@ -3791,7 +3791,7 @@ func TestGetDestinationsForGTPDNSPrefixes(t *testing.T) {
 						},
 					},
 				},
-				"outbound_.80_._.test-traffic-split.test-env.test-identity.global": {
+				"test-traffic-split.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "active-svc.test-ns.svc.cluster.local",
@@ -3811,7 +3811,7 @@ func TestGetDestinationsForGTPDNSPrefixes(t *testing.T) {
 						Weight: 90,
 					},
 				},
-				"outbound_.80_._.test-traffic-split.canary.test-env.test-identity.global": {
+				"test-traffic-split.canary.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "desired-svc.test-ns.svc.cluster.local",

--- a/admiral/pkg/clusters/virtualservice_routing_test.go
+++ b/admiral/pkg/clusters/virtualservice_routing_test.go
@@ -1366,7 +1366,7 @@ func TestPopulateVSRouteDestinationForRollout(t *testing.T) {
 			destinations:  make(map[string][]*vsrouting.RouteDestination),
 			expectedError: nil,
 			expectedRouteDestination: map[string][]*vsrouting.RouteDestination{
-				"outbound_.80_._.test-env.test-identity.global": {
+				"test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "active-svc.test-ns.svc.cluster.local",
@@ -1376,7 +1376,7 @@ func TestPopulateVSRouteDestinationForRollout(t *testing.T) {
 						},
 					},
 				},
-				"outbound_.80_._.preview.test-env.test-identity.global": {
+				"preview.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "preview-svc.test-ns.svc.cluster.local",
@@ -1443,7 +1443,7 @@ func TestPopulateVSRouteDestinationForRollout(t *testing.T) {
 			destinations:  make(map[string][]*vsrouting.RouteDestination),
 			expectedError: nil,
 			expectedRouteDestination: map[string][]*vsrouting.RouteDestination{
-				"outbound_.80_._.test-env.test-identity.global": {
+				"test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "canary-svc.test-ns.svc.cluster.local",
@@ -1463,7 +1463,7 @@ func TestPopulateVSRouteDestinationForRollout(t *testing.T) {
 						Weight: 90,
 					},
 				},
-				"outbound_.80_._.canary.test-env.test-identity.global": {
+				"canary.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "canary-svc.test-ns.svc.cluster.local",
@@ -1508,7 +1508,7 @@ func TestPopulateVSRouteDestinationForRollout(t *testing.T) {
 			destinations:  make(map[string][]*vsrouting.RouteDestination),
 			expectedError: nil,
 			expectedRouteDestination: map[string][]*vsrouting.RouteDestination{
-				"outbound_.80_._.test-env.test-identity.global": {
+				"test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "test-rollout-svc.test-ns.svc.cluster.local",
@@ -1640,7 +1640,7 @@ func TestPopulateDestinationsForBlueGreenStrategy(t *testing.T) {
 			destinations:  make(map[string][]*vsrouting.RouteDestination),
 			expectedError: nil,
 			expectedRouteDestination: map[string][]*vsrouting.RouteDestination{
-				"outbound_.80_._.test-env.test-identity.global": {
+				"test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "active-svc.test-ns.svc.cluster.local",
@@ -1650,7 +1650,7 @@ func TestPopulateDestinationsForBlueGreenStrategy(t *testing.T) {
 						},
 					},
 				},
-				"outbound_.80_._.preview.test-env.test-identity.global": {
+				"preview.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "preview-svc.test-ns.svc.cluster.local",
@@ -1793,7 +1793,7 @@ func TestPopulateDestinationsForCanaryStrategy(t *testing.T) {
 			destinations:  make(map[string][]*vsrouting.RouteDestination),
 			expectedError: nil,
 			expectedRouteDestination: map[string][]*vsrouting.RouteDestination{
-				"outbound_.80_._.test-env.test-identity.global": {
+				"test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "canary-svc.test-ns.svc.cluster.local",
@@ -1813,7 +1813,7 @@ func TestPopulateDestinationsForCanaryStrategy(t *testing.T) {
 						Weight: 90,
 					},
 				},
-				"outbound_.80_._.canary.test-env.test-identity.global": {
+				"canary.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "canary-svc.test-ns.svc.cluster.local",
@@ -2141,7 +2141,7 @@ func TestGetAllVSRouteDestinationsByCluster(t *testing.T) {
 			},
 			expectedError: nil,
 			expectedRouteDestination: map[string][]*vsrouting.RouteDestination{
-				"outbound_.80_._.test-env.test-identity.global": {
+				"test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "active-svc.test-ns.svc.cluster.local",
@@ -2151,7 +2151,7 @@ func TestGetAllVSRouteDestinationsByCluster(t *testing.T) {
 						},
 					},
 				},
-				"outbound_.80_._.preview.test-env.test-identity.global": {
+				"preview.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "preview-svc.test-ns.svc.cluster.local",
@@ -2192,7 +2192,7 @@ func TestGetAllVSRouteDestinationsByCluster(t *testing.T) {
 			},
 			expectedError: nil,
 			expectedRouteDestination: map[string][]*vsrouting.RouteDestination{
-				"outbound_.80_._.test-env.test-identity.global": {
+				"test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "test-deployment-svc.test-ns.svc.cluster.local",
@@ -2272,7 +2272,7 @@ func TestGetAllVSRouteDestinationsByCluster(t *testing.T) {
 			},
 			expectedError: nil,
 			expectedRouteDestination: map[string][]*vsrouting.RouteDestination{
-				"outbound_.80_._.test-env.test-identity.global": {
+				"test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "active-svc.test-ns.svc.cluster.local",
@@ -2290,7 +2290,7 @@ func TestGetAllVSRouteDestinationsByCluster(t *testing.T) {
 						},
 					},
 				},
-				"outbound_.80_._.preview.test-env.test-identity.global": {
+				"preview.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "preview-svc.test-ns.svc.cluster.local",
@@ -2426,7 +2426,7 @@ func TestProcessGTPAndAddWeightsByCluster(t *testing.T) {
 			expectedError:         nil,
 			updateWeights:         true,
 			destinations: map[string][]*vsrouting.RouteDestination{
-				"outbound_.80_._.test-env.test-identity.global": {
+				"test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "active-svc.test-ns.svc.cluster.local",
@@ -2446,7 +2446,7 @@ func TestProcessGTPAndAddWeightsByCluster(t *testing.T) {
 						Weight: 20,
 					},
 				},
-				"outbound_.80_._.preview.test-env.test-identity.global": {
+				"preview.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "preview-svc.test-ns.svc.cluster.local",
@@ -2456,7 +2456,7 @@ func TestProcessGTPAndAddWeightsByCluster(t *testing.T) {
 						},
 					},
 				},
-				"outbound_.80_._.canary.test-env.test-identity.global": {
+				"canary.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "desired-svc.test-ns.svc.cluster.local",
@@ -2468,7 +2468,7 @@ func TestProcessGTPAndAddWeightsByCluster(t *testing.T) {
 				},
 			},
 			expectedRouteDestination: map[string][]*vsrouting.RouteDestination{
-				"outbound_.80_._.test-env.test-identity.global": {
+				"test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "active-svc.test-ns.svc.cluster.local",
@@ -2488,7 +2488,7 @@ func TestProcessGTPAndAddWeightsByCluster(t *testing.T) {
 						Weight: 20,
 					},
 				},
-				"outbound_.80_._.preview.test-env.test-identity.global": {
+				"preview.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "preview-svc.test-ns.svc.cluster.local",
@@ -2498,7 +2498,7 @@ func TestProcessGTPAndAddWeightsByCluster(t *testing.T) {
 						},
 					},
 				},
-				"outbound_.80_._.canary.test-env.test-identity.global": {
+				"canary.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "desired-svc.test-ns.svc.cluster.local",
@@ -2508,7 +2508,7 @@ func TestProcessGTPAndAddWeightsByCluster(t *testing.T) {
 						},
 					},
 				},
-				"outbound_.80_._.west.test-env.test-identity.global": {
+				"west.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "active-svc.test-ns.svc.cluster.local",
@@ -2528,7 +2528,7 @@ func TestProcessGTPAndAddWeightsByCluster(t *testing.T) {
 						Weight: 20,
 					},
 				},
-				"outbound_.80_._.west.canary.test-env.test-identity.global": {
+				"west.canary.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "desired-svc.test-ns.svc.cluster.local",
@@ -2538,7 +2538,7 @@ func TestProcessGTPAndAddWeightsByCluster(t *testing.T) {
 						},
 					},
 				},
-				"outbound_.80_._.east.test-env.test-identity.global": {
+				"east.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "active-svc.test-ns.svc.cluster.local",
@@ -2567,7 +2567,7 @@ func TestProcessGTPAndAddWeightsByCluster(t *testing.T) {
 						Weight: 20,
 					},
 				},
-				"outbound_.80_._.east.canary.test-env.test-identity.global": {
+				"east.canary.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "desired-svc.test-ns.svc.cluster.local",
@@ -2600,7 +2600,7 @@ func TestProcessGTPAndAddWeightsByCluster(t *testing.T) {
 			updateWeights:         false,
 			sourceClusterLocality: "us-east-2",
 			destinations: map[string][]*vsrouting.RouteDestination{
-				"outbound_.80_._.test-env.test-identity.global": {
+				"test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "active-svc.test-ns.svc.cluster.local",
@@ -2610,7 +2610,7 @@ func TestProcessGTPAndAddWeightsByCluster(t *testing.T) {
 						},
 					},
 				},
-				"outbound_.80_._.preview.test-env.test-identity.global": {
+				"preview.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "preview-svc.test-ns.svc.cluster.local",
@@ -2620,7 +2620,7 @@ func TestProcessGTPAndAddWeightsByCluster(t *testing.T) {
 						},
 					},
 				},
-				"outbound_.80_._.canary.test-env.test-identity.global": {
+				"canary.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "desired-svc.test-ns.svc.cluster.local",
@@ -2632,7 +2632,7 @@ func TestProcessGTPAndAddWeightsByCluster(t *testing.T) {
 				},
 			},
 			expectedRouteDestination: map[string][]*vsrouting.RouteDestination{
-				"outbound_.80_._.test-env.test-identity.global": {
+				"test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "active-svc.test-ns.svc.cluster.local",
@@ -2642,7 +2642,7 @@ func TestProcessGTPAndAddWeightsByCluster(t *testing.T) {
 						},
 					},
 				},
-				"outbound_.80_._.preview.test-env.test-identity.global": {
+				"preview.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "preview-svc.test-ns.svc.cluster.local",
@@ -2652,7 +2652,7 @@ func TestProcessGTPAndAddWeightsByCluster(t *testing.T) {
 						},
 					},
 				},
-				"outbound_.80_._.canary.test-env.test-identity.global": {
+				"canary.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "desired-svc.test-ns.svc.cluster.local",
@@ -2662,7 +2662,7 @@ func TestProcessGTPAndAddWeightsByCluster(t *testing.T) {
 						},
 					},
 				},
-				"outbound_.80_._.east.test-env.test-identity.global": {
+				"east.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "active-svc.test-ns.svc.cluster.local",
@@ -2672,7 +2672,7 @@ func TestProcessGTPAndAddWeightsByCluster(t *testing.T) {
 						},
 					},
 				},
-				"outbound_.80_._.west.test-env.test-identity.global": {
+				"west.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "active-svc.test-ns.svc.cluster.local",
@@ -2682,7 +2682,7 @@ func TestProcessGTPAndAddWeightsByCluster(t *testing.T) {
 						},
 					},
 				},
-				"outbound_.80_._.east.canary.test-env.test-identity.global": {
+				"east.canary.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "desired-svc.test-ns.svc.cluster.local",
@@ -2692,7 +2692,7 @@ func TestProcessGTPAndAddWeightsByCluster(t *testing.T) {
 						},
 					},
 				},
-				"outbound_.80_._.west.canary.test-env.test-identity.global": {
+				"west.canary.test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "desired-svc.test-ns.svc.cluster.local",

--- a/admiral/pkg/clusters/virtualservice_routing_test.go
+++ b/admiral/pkg/clusters/virtualservice_routing_test.go
@@ -238,6 +238,7 @@ func TestAddUpdateInClusterVirtualServices(t *testing.T) {
 					ExportTo: []string{"test-dependent-ns0", "test-dependent-ns1", "test-ns"},
 					Http: []*networkingV1Alpha3.HTTPRoute{
 						{
+							Name: "test-env.test-identity.global",
 							Match: []*networkingV1Alpha3.HTTPMatchRequest{
 								{
 									Authority: &networkingV1Alpha3.StringMatch{
@@ -283,6 +284,7 @@ func TestAddUpdateInClusterVirtualServices(t *testing.T) {
 					ExportTo: []string{"test-dependent-ns0", "test-dependent-ns1", "test-ns"},
 					Http: []*networkingV1Alpha3.HTTPRoute{
 						{
+							Name: "test-env.test-identity.global",
 							Match: []*networkingV1Alpha3.HTTPMatchRequest{
 								{
 									Authority: &networkingV1Alpha3.StringMatch{
@@ -331,6 +333,7 @@ func TestAddUpdateInClusterVirtualServices(t *testing.T) {
 					ExportTo: []string{"test-dependent-ns0", "test-dependent-ns1", "test-ns"},
 					Http: []*networkingV1Alpha3.HTTPRoute{
 						{
+							Name: "preview.test-env.test-identity.global",
 							Match: []*networkingV1Alpha3.HTTPMatchRequest{
 								{
 									Authority: &networkingV1Alpha3.StringMatch{
@@ -352,6 +355,7 @@ func TestAddUpdateInClusterVirtualServices(t *testing.T) {
 							},
 						},
 						{
+							Name: "test-env.test-identity.global",
 							Match: []*networkingV1Alpha3.HTTPMatchRequest{
 								{
 									Authority: &networkingV1Alpha3.StringMatch{
@@ -400,6 +404,7 @@ func TestAddUpdateInClusterVirtualServices(t *testing.T) {
 					ExportTo: []string{"test-dependent-ns0", "test-dependent-ns1", "test-ns"},
 					Http: []*networkingV1Alpha3.HTTPRoute{
 						{
+							Name: "canary.test-env.test-identity.global",
 							Match: []*networkingV1Alpha3.HTTPMatchRequest{
 								{
 									Authority: &networkingV1Alpha3.StringMatch{
@@ -421,6 +426,7 @@ func TestAddUpdateInClusterVirtualServices(t *testing.T) {
 							},
 						},
 						{
+							Name: "test-env.test-identity.global",
 							Match: []*networkingV1Alpha3.HTTPMatchRequest{
 								{
 									Authority: &networkingV1Alpha3.StringMatch{
@@ -476,6 +482,7 @@ func TestAddUpdateInClusterVirtualServices(t *testing.T) {
 					ExportTo: []string{"test-dependent-ns0", "test-dependent-ns1", "test-ns"},
 					Http: []*networkingV1Alpha3.HTTPRoute{
 						{
+							Name: "test-env.test-identity.global",
 							Match: []*networkingV1Alpha3.HTTPMatchRequest{
 								{
 									Authority: &networkingV1Alpha3.StringMatch{

--- a/admiral/pkg/clusters/virtualservice_routing_test.go
+++ b/admiral/pkg/clusters/virtualservice_routing_test.go
@@ -1167,7 +1167,7 @@ func TestPopulateVSRouteDestinationForDeployment(t *testing.T) {
 			},
 			expectedError: nil,
 			expectedRouteDestination: map[string][]*vsrouting.RouteDestination{
-				"outbound_.80_._.test-env.test-identity.global": {
+				"test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "test-deployment-svc.test-ns.svc.cluster.local",
@@ -1205,7 +1205,7 @@ func TestPopulateVSRouteDestinationForDeployment(t *testing.T) {
 				},
 			},
 			destinations: map[string][]*vsrouting.RouteDestination{
-				"outbound_.80_._.test-env.test-identity.global": {
+				"test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "test-deployment-svc.test-ns.svc.cluster.local",
@@ -1218,7 +1218,7 @@ func TestPopulateVSRouteDestinationForDeployment(t *testing.T) {
 			},
 			expectedError: nil,
 			expectedRouteDestination: map[string][]*vsrouting.RouteDestination{
-				"outbound_.80_._.test-env.test-identity.global": {
+				"test-env.test-identity.global": {
 					{
 						Destination: &networkingV1Alpha3.Destination{
 							Host: "test-deployment-svc.test-ns.svc.cluster.local",


### PR DESCRIPTION
Refactor vs routing code

Modified the `FQDN -> []RouteDestination` map's key from SNI FQDN to regular FQDN. 
I change it to SNI FQDN when generating the VS for ingress

Also, added FQDN as a name to each route. This I'll use to build the cache in controller later