### PR TITLE
handle canary rollout weight for destination with one weighted service

### DIFF
--- a/admiral/pkg/clusters/virtualservice_routing.go
+++ b/admiral/pkg/clusters/virtualservice_routing.go
@@ -433,7 +433,7 @@ func populateDestinationsForCanaryStrategy(
 		if destinations[defaultFQDN] == nil {
 			destinations[defaultFQDN] = make([]*vsrouting.RouteDestination, 0)
 		}
-		if service.Weight > 0 {
+		if service.Weight > 0 && len(weightedServices) > 1 {
 			weight = service.Weight
 		}
 		destinations[defaultFQDN] = append(destinations[defaultFQDN], getRouteDestination(host, meshPort, weight))


### PR DESCRIPTION
### Checklist
🚨 Please review this repository's [contribution guidelines](./CONTRIBUTING.md).

- [X] I've read and agree to the project's contribution guidelines.
- [X] I'm requesting to feature.
- [X] I checked that my code additions will pass code linting checks and unit tests.
- [X] I updated unit and integration tests (if applicable).
- [X] I'm ready to notify the team of this contribution.

### Description
What does this change do and why?
Handle incluster and routing vs based routing configuration for canary rollouts, when the weighted services are one for the route destinations

Thank you!