### PR TITLE
MESH-6401: handle exportTo on in-cluster VS

### DIFF
--- a/admiral/cmd/admiral/cmd/root.go
+++ b/admiral/cmd/admiral/cmd/root.go
@@ -278,7 +278,9 @@ func GetRootCmd(args []string) *cobra.Command {
 
 	// Flags pertaining to VS based routing in-cluster
 	rootCmd.PersistentFlags().BoolVar(&params.EnableVSRoutingInCluster, "enable_vs_routing_in_cluster", false, "Enable/Disable VS Based Routing in cluster")
+	// Usage:  --vs_routing_in_cluster_enabled_resources *=identity1,cluster2=*,cluster3="identity3, identity4" OR --vs_routing_in_cluster_enabled_resources *=* (enable for everything)
 	rootCmd.PersistentFlags().StringToStringVarP(&params.VSRoutingInClusterEnabledResources, "vs_routing_in_cluster_enabled_resources", "e", map[string]string{}, "The source clusters and corresponding source identities to enable VS based routing in-cluster on")
+	// Usage:  --vs_routing_in_cluster_disabled_resources *=identity1,cluster2=*,cluster3="identity3, identity4" OR --vs_routing_in_cluster_disabled_resources *=* (disable for everything)
 	rootCmd.PersistentFlags().StringToStringVarP(&params.VSRoutingInClusterDisabledResources, "vs_routing_in_cluster_disabled_resources", "d", map[string]string{}, "The source clusters and corresponding source identities to disable VS based routing in-cluster on")
 
 	rootCmd.PersistentFlags().BoolVar(&params.EnableClientDiscovery, "enable_client_discovery", true, "Enable/Disable Client (mesh egress) Discovery")

--- a/admiral/cmd/admiral/cmd/root.go
+++ b/admiral/cmd/admiral/cmd/root.go
@@ -278,10 +278,8 @@ func GetRootCmd(args []string) *cobra.Command {
 
 	// Flags pertaining to VS based routing in-cluster
 	rootCmd.PersistentFlags().BoolVar(&params.EnableVSRoutingInCluster, "enable_vs_routing_in_cluster", false, "Enable/Disable VS Based Routing in cluster")
-	rootCmd.PersistentFlags().StringSliceVar(&params.VSRoutingInClusterEnabledClusters, "vs_routing_in_cluster_enabled_clusters", []string{}, "The source clusters to enable VS based routing in-cluster on")
-	rootCmd.PersistentFlags().StringSliceVar(&params.VSRoutingInClusterEnabledIdentities, "vs_routing_in_cluster_enabled_identities", []string{}, "The identities to enable VS based routing in-cluster on")
-	rootCmd.PersistentFlags().StringSliceVar(&params.VSRoutingInClusterDisabledClusters, "vs_routing_in_cluster_disabled_clusters", []string{}, "The source clusters to disable VS based routing in-cluster on")
-	rootCmd.PersistentFlags().StringSliceVar(&params.VSRoutingInClusterDisabledIdentities, "vs_routing_in_cluster_disabled_identities", []string{}, "The identities to disable VS based routing in-cluster on")
+	rootCmd.PersistentFlags().StringToStringVarP(&params.VSRoutingInClusterEnabledResources, "vs_routing_in_cluster_enabled_resources", "e", map[string]string{}, "The source clusters and corresponding source identities to enable VS based routing in-cluster on")
+	rootCmd.PersistentFlags().StringToStringVarP(&params.VSRoutingInClusterDisabledResources, "vs_routing_in_cluster_disabled_resources", "d", map[string]string{}, "The source clusters and corresponding source identities to disable VS based routing in-cluster on")
 
 	rootCmd.PersistentFlags().BoolVar(&params.EnableClientDiscovery, "enable_client_discovery", true, "Enable/Disable Client (mesh egress) Discovery")
 	rootCmd.PersistentFlags().StringSliceVar(&params.ClientDiscoveryClustersForJobs, "client_discovery_clusters_for_jobs", []string{}, "List of clusters for client discovery for k8s jobs")

--- a/admiral/pkg/clusters/destinationrule_handler_test.go
+++ b/admiral/pkg/clusters/destinationrule_handler_test.go
@@ -1860,8 +1860,7 @@ func TestGetDestinationRuleVSRoutingInCluster(t *testing.T) {
 	}
 	admiralParams.EnableActivePassive = false
 	admiralParams.EnableVSRoutingInCluster = true
-	admiralParams.VSRoutingInClusterEnabledClusters = []string{"*"}
-	admiralParams.VSRoutingInClusterEnabledIdentities = []string{"*"}
+	admiralParams.VSRoutingInClusterEnabledResources = map[string]string{"*": "*"}
 	common.ResetSync()
 	common.InitializeConfig(admiralParams)
 

--- a/admiral/pkg/clusters/serviceentry.go
+++ b/admiral/pkg/clusters/serviceentry.go
@@ -783,91 +783,73 @@ func modifyServiceEntryForNewServiceOrPod(
 		// Discovery phase: This is where we build a map of all the svc.cluster.local destinations
 		// for the identity's source cluster. This map will contain the RouteDestination of all svc.cluster.local
 		// endpoints.
-		if common.DoVSRoutingForCluster(sourceCluster) || common.DoVSRoutingInClusterForCluster(sourceCluster) {
-			eventNamespace := sourceClusterToEventNsCache[sourceCluster]
-			ctxLogger.Infof(common.CtxLogFormat, "VSBasedRouting",
+		eventNamespace = sourceClusterToEventNsCache[sourceCluster]
+		ctxLogger.Infof(common.CtxLogFormat, "VSBasedRouting",
+			deploymentOrRolloutName, eventNamespace, sourceCluster,
+			"Discovery phase: VS based routing enabled for cluster")
+
+		sourceClusterLocality, err = getClusterRegion(remoteRegistry, sourceCluster, rc)
+		if err != nil {
+			ctxLogger.Warnf(common.CtxLogFormat, "VSBasedRouting",
+				deploymentOrRolloutName, eventNamespace, sourceCluster, err)
+		}
+
+		ingressDestinations, err = getAllVSRouteDestinationsByCluster(
+			ctxLogger,
+			serviceInstance,
+			meshDeployAndRolloutPorts,
+			sourceWeightedServices[sourceCluster],
+			sourceRollouts[sourceCluster],
+			sourceDeployments[sourceCluster])
+
+		if err != nil {
+			ctxLogger.Errorf(common.CtxLogFormat, "getAllVSRouteDestinationsByCluster",
+				deploymentOrRolloutName, eventNamespace, sourceCluster, err)
+			modifySEerr = common.AppendError(modifySEerr, err)
+		} else if len(ingressDestinations) == 0 {
+			ctxLogger.Warnf(common.CtxLogFormat, "getAllVSRouteDestinationsByCluster",
 				deploymentOrRolloutName, eventNamespace, sourceCluster,
-				"Discovery phase: VS based routing enabled for cluster")
-
-			sourceClusterLocality, err = getClusterRegion(remoteRegistry, sourceCluster, rc)
-			if err != nil {
-				ctxLogger.Warnf(common.CtxLogFormat, "VSBasedRouting",
-					deploymentOrRolloutName, eventNamespace, sourceCluster, err)
-			}
-
-			ingressDestinations, err = getAllVSRouteDestinationsByCluster(
-				ctxLogger,
-				serviceInstance,
-				meshDeployAndRolloutPorts,
-				sourceWeightedServices[sourceCluster],
-				sourceRollouts[sourceCluster],
-				sourceDeployments[sourceCluster])
-
-			if err != nil {
-				ctxLogger.Errorf(common.CtxLogFormat, "getAllVSRouteDestinationsByCluster",
-					deploymentOrRolloutName, eventNamespace, sourceCluster, err)
-				modifySEerr = common.AppendError(modifySEerr, err)
-			} else if len(ingressDestinations) == 0 {
-				ctxLogger.Warnf(common.CtxLogFormat, "getAllVSRouteDestinationsByCluster",
-					deploymentOrRolloutName, eventNamespace, sourceCluster,
-					"No RouteDestinations generated for VS based routing ")
-			} else {
-				for key, value := range ingressDestinations {
-					inClusterDestinations[key] = value
-				}
-			}
-
-			drHost := fmt.Sprintf("*.%s%s", eventNamespace, common.DotLocalDomainSuffix)
-			sourceClusterToDRHosts[sourceCluster] = map[string]string{
-				eventNamespace + common.DotLocalDomainSuffix: drHost,
-			}
+				"No RouteDestinations generated for VS based routing ")
 		} else {
-			ctxLogger.Infof(common.CtxLogFormat, "VSBasedRouting",
-				"", "", sourceCluster,
-				"Discovery phase: VS based routing disabled for cluster")
+			for key, value := range ingressDestinations {
+				inClusterDestinations[key] = value
+			}
+		}
+
+		drHost := fmt.Sprintf("*.%s%s", eventNamespace, common.DotLocalDomainSuffix)
+		sourceClusterToDRHosts[sourceCluster] = map[string]string{
+			eventNamespace + common.DotLocalDomainSuffix: drHost,
 		}
 
 		//Discovery Phase: process ingress routing destinations with dns prefixes based on GTP. No GTP weights are updated for ingress destinations
-		if common.DoVSRoutingForCluster(sourceCluster) {
-			err = processGTPAndAddWeightsByCluster(ctxLogger,
-				remoteRegistry,
-				sourceIdentity,
-				env,
-				sourceClusterLocality,
-				ingressDestinations,
-				false)
-			if err != nil {
-				ctxLogger.Errorf(common.CtxLogFormat, "processGTPAndAddWeightsByCluster",
-					deploymentOrRolloutName, eventNamespace, sourceCluster, err)
-				modifySEerr = common.AppendError(modifySEerr, err)
-			}
-			sourceClusterToDestinations[sourceCluster] = ingressDestinations
-		} else {
-			ctxLogger.Infof(common.CtxLogFormat, "processGTPAndAddWeightsByCluster",
-				"", "", sourceCluster,
-				"Discovery phase: Skipped GTP processing as VS based routing disabled for cluster")
+		err = processGTPAndAddWeightsByCluster(ctxLogger,
+			remoteRegistry,
+			sourceIdentity,
+			env,
+			sourceClusterLocality,
+			ingressDestinations,
+			false)
+		if err != nil {
+			ctxLogger.Errorf(common.CtxLogFormat, "processGTPAndAddWeightsByCluster",
+				deploymentOrRolloutName, eventNamespace, sourceCluster, err)
+			modifySEerr = common.AppendError(modifySEerr, err)
 		}
+		sourceClusterToDestinations[sourceCluster] = ingressDestinations
 
 		//Discovery Phase: process in-cluster routing destinations with dns prefixes and weights based on GTP
-		if common.DoVSRoutingInClusterForCluster(sourceCluster) && common.DoVSRoutingInClusterForIdentity(sourceIdentity) {
-			err = processGTPAndAddWeightsByCluster(ctxLogger,
-				remoteRegistry,
-				sourceIdentity,
-				env,
-				sourceClusterLocality,
-				inClusterDestinations,
-				true)
-			if err != nil {
-				ctxLogger.Errorf(common.CtxLogFormat, "processGTPAndAddWeightsByCluster",
-					deploymentOrRolloutName, eventNamespace, sourceCluster, err)
-				modifySEerr = common.AppendError(modifySEerr, err)
-			}
-			sourceClusterToInClusterDestinations[sourceCluster] = inClusterDestinations
-		} else {
-			ctxLogger.Infof(common.CtxLogFormat, "processGTPAndAddWeightsByCluster",
-				sourceIdentity, "", sourceCluster,
-				"Discovery phase: Skipped GTP processing as in-cluster VS based routing disabled for cluster")
+		err = processGTPAndAddWeightsByCluster(ctxLogger,
+			remoteRegistry,
+			sourceIdentity,
+			env,
+			sourceClusterLocality,
+			inClusterDestinations,
+			true)
+		if err != nil {
+			ctxLogger.Errorf(common.CtxLogFormat, "processGTPAndAddWeightsByCluster",
+				deploymentOrRolloutName, eventNamespace, sourceCluster, err)
+			modifySEerr = common.AppendError(modifySEerr, err)
 		}
+		sourceClusterToInClusterDestinations[sourceCluster] = inClusterDestinations
 	}
 
 	ctxLogger.Infof(common.CtxLogFormat, "ClientAssets",

--- a/admiral/pkg/clusters/serviceentry.go
+++ b/admiral/pkg/clusters/serviceentry.go
@@ -1545,6 +1545,7 @@ func AddServiceEntriesWithDrWorker(
 		ctxLogger.Infof("currentDR set for dr=%v cluster=%v", getIstioResourceName(se.Hosts[0], "-default-dr"), cluster)
 
 		doDRUpdateForInClusterVSRouting := common.DoDRUpdateForInClusterVSRouting(cluster, identityId, isServiceEntryModifyCalledForSourceCluster)
+		ctxLogger.Infof(common.CtxLogFormat, "AddServiceEntriesWithDrWorker", "", "", cluster, fmt.Sprintf("VSRoutingInClusterEnabled: %v for cluster: %s and Identity: %s", doDRUpdateForInClusterVSRouting, cluster, identityId))
 		var seDrSet, clientNamespaces = createSeAndDrSetFromGtp(ctxLogger, ctx, env, region, cluster, se,
 			globalTrafficPolicy, outlierDetection, clientConnectionSettings, cache, currentDR, doDRUpdateForInClusterVSRouting)
 		util.LogElapsedTimeSinceTask(ctxLogger, "AdmiralCacheCreateSeAndDrSetFromGtp", "", "", cluster, "", start)

--- a/admiral/pkg/clusters/virtualservice_routing.go
+++ b/admiral/pkg/clusters/virtualservice_routing.go
@@ -526,13 +526,17 @@ func generateVirtualServiceForIncluster(
 
 	// Add the exportTo namespaces to the virtual service
 	virtualService.Spec.ExportTo = []string{common.GetSyncNamespace()}
+	vsRoutingInclusterEnabledForClusterAndIdentity := false
 	if common.EnableExportTo(vsName) && common.DoVSRoutingInClusterForClusterAndIdentity(sourceCluster, sourceIdentity) {
+		vsRoutingInclusterEnabledForClusterAndIdentity = true
 		virtualService.Spec.ExportTo = getSortedDependentNamespaces(
 			remoteRegistry.AdmiralCache, vsName, sourceCluster, ctxLogger, true)
 	}
+	ctxLogger.Infof(common.CtxLogFormat, "VSBasedRoutingInCluster",
+		virtualService.Name, virtualService.Namespace, sourceCluster,
+		fmt.Sprintf("Writing phase: generateVirtualServiceForIncluster: VSRoutingInClusterEnabled: %v", vsRoutingInclusterEnabledForClusterAndIdentity))
 
 	return virtualService, nil
-
 }
 
 // generateVirtualServiceForIngress generates the VirtualService for the cross-cluster routing

--- a/admiral/pkg/clusters/virtualservice_routing_test.go
+++ b/admiral/pkg/clusters/virtualservice_routing_test.go
@@ -63,14 +63,13 @@ func TestAddUpdateInClusterVirtualServices(t *testing.T) {
 	}
 
 	admiralParams := common.AdmiralParams{
-		SyncNamespace:                       "admiral-sync",
-		LabelSet:                            &common.LabelSet{},
-		ExportToIdentityList:                []string{"*"},
-		ExportToMaxNamespaces:               100,
-		EnableSWAwareNSCaches:               true,
-		EnableVSRoutingInCluster:            true,
-		VSRoutingInClusterEnabledIdentities: []string{"test-identity"},
-		VSRoutingInClusterEnabledClusters:   []string{"cluster-1"},
+		SyncNamespace:                      "admiral-sync",
+		LabelSet:                           &common.LabelSet{},
+		ExportToIdentityList:               []string{"*"},
+		ExportToMaxNamespaces:              100,
+		EnableSWAwareNSCaches:              true,
+		EnableVSRoutingInCluster:           true,
+		VSRoutingInClusterEnabledResources: map[string]string{"cluster-1": "test-identity"},
 	}
 	common.ResetSync()
 	common.InitializeConfig(admiralParams)
@@ -3266,14 +3265,13 @@ func TestAddUpdateInClusterDestinationRule(t *testing.T) {
 	}
 
 	admiralParams := common.AdmiralParams{
-		SANPrefix:                           "test-san-prefix",
-		EnableVSRoutingInCluster:            true,
-		VSRoutingInClusterEnabledClusters:   []string{"cluster-1", "cluster-2"},
-		VSRoutingInClusterEnabledIdentities: []string{"test-identity"},
-		VSRoutingSlowStartEnabledClusters:   []string{"cluster-1"},
-		ExportToIdentityList:                []string{"*"},
-		ExportToMaxNamespaces:               100,
-		EnableSWAwareNSCaches:               true,
+		SANPrefix:                          "test-san-prefix",
+		EnableVSRoutingInCluster:           true,
+		VSRoutingInClusterEnabledResources: map[string]string{"cluster-1": "test-identity", "cluster-2": "*"},
+		VSRoutingSlowStartEnabledClusters:  []string{"cluster-1"},
+		ExportToIdentityList:               []string{"*"},
+		ExportToMaxNamespaces:              100,
+		EnableSWAwareNSCaches:              true,
 	}
 
 	common.ResetSync()
@@ -4363,14 +4361,13 @@ func TestPerformInVSRoutingRollback(t *testing.T) {
 	}
 
 	admiralParams := common.AdmiralParams{
-		LabelSet:                             &common.LabelSet{},
-		SyncNamespace:                        "test-sync-ns",
-		ExportToIdentityList:                 []string{"*"},
-		ExportToMaxNamespaces:                100,
-		EnableSWAwareNSCaches:                true,
-		EnableVSRoutingInCluster:             true,
-		VSRoutingInClusterDisabledIdentities: []string{"test-identity"},
-		VSRoutingInClusterDisabledClusters:   []string{"cluster-2"},
+		LabelSet:                            &common.LabelSet{},
+		SyncNamespace:                       "test-sync-ns",
+		ExportToIdentityList:                []string{"*"},
+		ExportToMaxNamespaces:               100,
+		EnableSWAwareNSCaches:               true,
+		EnableVSRoutingInCluster:            true,
+		VSRoutingInClusterDisabledResources: map[string]string{"cluster-2": "*", "cluster-1": "test-identity"},
 	}
 	common.ResetSync()
 	common.InitializeConfig(admiralParams)

--- a/admiral/pkg/controller/common/config.go
+++ b/admiral/pkg/controller/common/config.go
@@ -547,12 +547,12 @@ func DoVSRoutingInClusterForClusterAndIdentity(cluster, identity string) bool {
 
 // Verify the specific identity is part of the configured identities
 func checkClusterIdentity(identities string, identity string) bool {
-	if identities == "*" {
+	if strings.TrimSpace(identities) == "*" {
 		return true
 	}
 
 	for _, id := range strings.Split(identities, ",") {
-		if id == identity {
+		if strings.TrimSpace(id) == strings.TrimSpace(identity) {
 			return true
 		}
 	}

--- a/admiral/pkg/controller/common/config_test.go
+++ b/admiral/pkg/controller/common/config_test.go
@@ -314,82 +314,75 @@ func TestDoDRUpdateForInClusterVSRouting(t *testing.T) {
 	p := AdmiralParams{}
 
 	testCases := []struct {
-		name                                   string
-		cluster                                string
-		identity                               string
-		isSourceCluster                        bool
-		enableVSRoutingInCluster               bool
-		enabledVSRoutingInClusterForCluster    []string
-		enabledVSRoutingInClusterForIdentities []string
-		expected                               bool
+		name                               string
+		cluster                            string
+		identity                           string
+		isSourceCluster                    bool
+		enableVSRoutingInCluster           bool
+		enabledVSRoutingInClusterResources map[string]string
+		expected                           bool
 	}{
 		{
 			name: "Given VSRoutingInCluster is enabled for cluster1 and identity1, cluster is source cluster" +
 				"When DoDRUpdateForInClusterVSRouting is called" +
 				"Then it should return true",
-			cluster:                                "cluster1",
-			identity:                               "identity1",
-			isSourceCluster:                        true,
-			enableVSRoutingInCluster:               true,
-			enabledVSRoutingInClusterForCluster:    []string{"cluster1"},
-			enabledVSRoutingInClusterForIdentities: []string{"identity1"},
-			expected:                               true,
+			cluster:                            "cluster1",
+			identity:                           "identity1",
+			isSourceCluster:                    true,
+			enableVSRoutingInCluster:           true,
+			enabledVSRoutingInClusterResources: map[string]string{"cluster1": "identity1"},
+			expected:                           true,
 		},
 		{
 			name: "Given VSRoutingInCluster is enabled for cluster1 and identity1, cluster is remote cluster" +
 				"When DoDRUpdateForInClusterVSRouting is called" +
 				"Then it should return true",
-			cluster:                                "cluster1",
-			identity:                               "identity1",
-			isSourceCluster:                        false,
-			enableVSRoutingInCluster:               true,
-			enabledVSRoutingInClusterForCluster:    []string{"cluster1"},
-			enabledVSRoutingInClusterForIdentities: []string{"identity1"},
-			expected:                               false,
+			cluster:                            "cluster1",
+			identity:                           "identity1",
+			isSourceCluster:                    false,
+			enableVSRoutingInCluster:           true,
+			enabledVSRoutingInClusterResources: map[string]string{"cluster1": "identity1"},
+			expected:                           false,
 		},
 		{
 			name: "Given VSRoutingInCluster is not enabled for cluster1, cluster is source cluster" +
 				"When DoDRUpdateForInClusterVSRouting is called" +
 				"Then it should return true",
-			cluster:                                "cluster1",
-			identity:                               "identity1",
-			isSourceCluster:                        true,
-			enableVSRoutingInCluster:               true,
-			enabledVSRoutingInClusterForCluster:    []string{"cluster2"},
-			enabledVSRoutingInClusterForIdentities: []string{},
-			expected:                               false,
+			cluster:                            "cluster1",
+			identity:                           "identity1",
+			isSourceCluster:                    true,
+			enableVSRoutingInCluster:           true,
+			enabledVSRoutingInClusterResources: map[string]string{"cluster2": ""},
+			expected:                           false,
 		},
 		{
 			name: "Given VSRoutingInCluster is not enabled, cluster is source cluster" +
 				"When DoDRUpdateForInClusterVSRouting is called" +
 				"Then it should return true",
-			cluster:                                "cluster1",
-			identity:                               "identity1",
-			isSourceCluster:                        true,
-			enableVSRoutingInCluster:               false,
-			enabledVSRoutingInClusterForCluster:    []string{},
-			enabledVSRoutingInClusterForIdentities: []string{},
-			expected:                               false,
+			cluster:                            "cluster1",
+			identity:                           "identity1",
+			isSourceCluster:                    true,
+			enableVSRoutingInCluster:           false,
+			enabledVSRoutingInClusterResources: map[string]string{"": ""},
+			expected:                           false,
 		},
 		{
 			name: "Given VSRoutingInCluster is enabled for cluster1,  VSRoutingInCluster not enabled for identity1, cluster is source cluster" +
 				"When DoDRUpdateForInClusterVSRouting is called" +
 				"Then it should return true",
-			cluster:                                "cluster1",
-			identity:                               "identity1",
-			isSourceCluster:                        true,
-			enableVSRoutingInCluster:               true,
-			enabledVSRoutingInClusterForCluster:    []string{"cluster1"},
-			enabledVSRoutingInClusterForIdentities: []string{},
-			expected:                               false,
+			cluster:                            "cluster1",
+			identity:                           "identity1",
+			isSourceCluster:                    true,
+			enableVSRoutingInCluster:           true,
+			enabledVSRoutingInClusterResources: map[string]string{"cluster1": ""},
+			expected:                           false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			p.EnableVSRoutingInCluster = tc.enableVSRoutingInCluster
-			p.VSRoutingInClusterEnabledClusters = tc.enabledVSRoutingInClusterForCluster
-			p.VSRoutingInClusterEnabledIdentities = tc.enabledVSRoutingInClusterForIdentities
+			p.VSRoutingInClusterEnabledResources = tc.enabledVSRoutingInClusterResources
 			ResetSync()
 			InitializeConfig(p)
 
@@ -399,251 +392,171 @@ func TestDoDRUpdateForInClusterVSRouting(t *testing.T) {
 
 }
 
-func TestIsVSRoutingInClusterDisabledForCluster(t *testing.T) {
-	p := AdmiralParams{}
-
-	testCases := []struct {
-		name                                 string
-		cluster                              string
-		disabledVSRoutingInClusterForCluster []string
-		expected                             bool
-	}{
-		{
-			name: "Given disabledVSRoutingInClusterForCluster is empty" +
-				"When IsVSRoutingInClusterDisabledForCluster is called" +
-				"Then it should return false",
-			cluster:                              "cluster1",
-			disabledVSRoutingInClusterForCluster: []string{},
-			expected:                             false,
-		},
-		{
-			name: "Given cluster doesn't exists in the list" +
-				"When IsVSRoutingInClusterDisabledForCluster is called" +
-				"Then it should return false",
-			cluster:                              "cluster2",
-			disabledVSRoutingInClusterForCluster: []string{"cluster1"},
-			expected:                             false,
-		},
-		{
-			name: "Given cluster does exists in the list" +
-				"When IsVSRoutingInClusterDisabledForCluster is called" +
-				"Then it should return true",
-			cluster:                              "cluster1",
-			disabledVSRoutingInClusterForCluster: []string{"cluster1"},
-			expected:                             true,
-		},
-		{
-			name: "Given VS routing is disabled in all clusters using '*'" +
-				"When IsVSRoutingInClusterDisabledForCluster is called" +
-				"Then it should return true",
-			cluster:                              "cluster1",
-			disabledVSRoutingInClusterForCluster: []string{"*"},
-			expected:                             true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			p.VSRoutingInClusterDisabledClusters = tc.disabledVSRoutingInClusterForCluster
-			ResetSync()
-			InitializeConfig(p)
-
-			assert.Equal(t, tc.expected, IsVSRoutingInClusterDisabledForCluster(tc.cluster))
-		})
-	}
-
-}
-
-func TestIsVSRoutingInClusterDisabledForIdentity(t *testing.T) {
-	p := AdmiralParams{}
-
-	testCases := []struct {
-		name                                    string
-		identity                                string
-		disabledVSRoutingInClusterForIdentities []string
-		expected                                bool
-	}{
-		{
-			name: "Given disabledVSRoutingInClusterForIdentities is empty" +
-				"When IsVSRoutingInClusterDisabledForIdentity is called" +
-				"Then it should return false",
-			identity:                                "testIdentity1",
-			disabledVSRoutingInClusterForIdentities: []string{},
-			expected:                                false,
-		},
-		{
-			name: "Given identity doesn't exists in the list" +
-				"When IsVSRoutingInClusterDisabledForIdentity is called" +
-				"Then it should return false",
-			identity:                                "testIdentity2",
-			disabledVSRoutingInClusterForIdentities: []string{"testIdentity1"},
-			expected:                                false,
-		},
-		{
-			name: "Given identity does exists in the list" +
-				"When IsVSRoutingInClusterDisabledForIdentity is called" +
-				"Then it should return true",
-			identity:                                "testIdentity1",
-			disabledVSRoutingInClusterForIdentities: []string{"testIdentity1"},
-			expected:                                true,
-		},
-		{
-			name: "Given  VS routing is disabled for all identities using '*'" +
-				"When IsVSRoutingInClusterDisabledForIdentity is called" +
-				"Then it should return true",
-			identity:                                "testIdentity1",
-			disabledVSRoutingInClusterForIdentities: []string{"*"},
-			expected:                                true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			p.VSRoutingInClusterDisabledIdentities = tc.disabledVSRoutingInClusterForIdentities
-			ResetSync()
-			InitializeConfig(p)
-
-			assert.Equal(t, tc.expected, IsVSRoutingInClusterDisabledForIdentity(tc.identity))
-		})
-	}
-
-}
-
-func TestDoVSRoutingInClusterForCluster(t *testing.T) {
+func TestIsVSRoutingInClusterDisabledForClusterAndIdentity(t *testing.T) {
 	p := AdmiralParams{}
 
 	testCases := []struct {
 		name                                string
 		cluster                             string
-		enableVSRoutingInCluster            bool
-		enabledVSRoutingInClusterForCluster []string
+		identity                            string
+		disabledVSRoutingInClusterResources map[string]string
 		expected                            bool
 	}{
 		{
-			name: "Given enableVSRoutingInCluster is false, enabledVSRoutingInClusterForCluster is empty" +
-				"When DoVSRoutingInClusterForCluster is called" +
+			name: "Given disabledVSRoutingInClusterResources is empty" +
+				"When IsVSRoutingInClusterDisabledForIdentity is called" +
 				"Then it should return false",
 			cluster:                             "cluster1",
-			enableVSRoutingInCluster:            false,
-			enabledVSRoutingInClusterForCluster: []string{},
+			identity:                            "identity",
+			disabledVSRoutingInClusterResources: map[string]string{},
 			expected:                            false,
 		},
 		{
-			name: "Given enableVSRoutingInCluster is true, enabledVSRoutingInClusterForCluster is empty" +
-				"When DoVSRoutingInClusterForCluster is called" +
-				"Then it should return false",
-			cluster:                             "cluster1",
-			enableVSRoutingInCluster:            true,
-			enabledVSRoutingInClusterForCluster: []string{},
-			expected:                            false,
-		},
-		{
-			name: "Given enableVSRoutingInCluster is true, and given cluster doesn't exists in the list" +
-				"When DoVSRoutingInClusterForCluster is called" +
+			name: "Given cluster doesn't exists in the disabledVSRoutingInClusterResources" +
+				"When IsVSRoutingInClusterDisabledForIdentity is called" +
 				"Then it should return false",
 			cluster:                             "cluster2",
-			enableVSRoutingInCluster:            true,
-			enabledVSRoutingInClusterForCluster: []string{"cluster1"},
+			identity:                            "identity",
+			disabledVSRoutingInClusterResources: map[string]string{},
 			expected:                            false,
 		},
 		{
-			name: "Given enableVSRoutingInCluster is true, and given cluster does exists in the list" +
-				"When DoVSRoutingInClusterForCluster is called" +
+			name: "Given cluster does exists in the disabledVSRoutingInClusterResources" +
+				"When IsVSRoutingInClusterDisabledForIdentity is called" +
 				"Then it should return true",
 			cluster:                             "cluster1",
-			enableVSRoutingInCluster:            true,
-			enabledVSRoutingInClusterForCluster: []string{"cluster1"},
+			identity:                            "identity",
+			disabledVSRoutingInClusterResources: map[string]string{"cluster1": "*"},
 			expected:                            true,
 		},
 		{
-			name: "Given enableVSRoutingInCluster is true, and all VS routing is enabled in all clusters using '*'" +
-				"When DoVSRoutingInClusterForCluster is called" +
+			name: "Given VS routing is disabled in all clusters using '*'" +
+				"When IsVSRoutingInClusterDisabledForIdentity is called" +
 				"Then it should return true",
 			cluster:                             "cluster1",
-			enableVSRoutingInCluster:            true,
-			enabledVSRoutingInClusterForCluster: []string{"*"},
+			identity:                            "identity",
+			disabledVSRoutingInClusterResources: map[string]string{"*": "*"},
+			expected:                            true,
+		},
+		{
+			name: "Given cluster does exists in the disabledVSRoutingInClusterResources and given identity does not exists" +
+				"When IsVSRoutingInClusterDisabledForIdentity is called" +
+				"Then it should return false",
+			cluster:                             "cluster1",
+			identity:                            "identity1",
+			disabledVSRoutingInClusterResources: map[string]string{"cluster1": ""},
+			expected:                            false,
+		},
+		{
+			name: "Given cluster and identity does exists in the disabledVSRoutingInClusterResources" +
+				"When IsVSRoutingInClusterDisabledForIdentity is called" +
+				"Then it should return true",
+			cluster:                             "cluster1",
+			identity:                            "identity1",
+			disabledVSRoutingInClusterResources: map[string]string{"cluster1": "identity1"},
 			expected:                            true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			p.EnableVSRoutingInCluster = tc.enableVSRoutingInCluster
-			p.VSRoutingInClusterEnabledClusters = tc.enabledVSRoutingInClusterForCluster
+			p.VSRoutingInClusterDisabledResources = tc.disabledVSRoutingInClusterResources
 			ResetSync()
 			InitializeConfig(p)
 
-			assert.Equal(t, tc.expected, DoVSRoutingInClusterForCluster(tc.cluster))
+			assert.Equal(t, tc.expected, IsVSRoutingInClusterDisabledForIdentity(tc.cluster, tc.identity))
 		})
 	}
-
 }
 
-func TestDoVSRoutingInClusterForIdentity(t *testing.T) {
+func TestDoVSRoutingInClusterForClusterAndIdentity(t *testing.T) {
 	p := AdmiralParams{}
 
 	testCases := []struct {
-		name                                   string
-		identity                               string
-		enableVSRoutingInCluster               bool
-		enabledVSRoutingInClusterForIdentities []string
-		expected                               bool
+		name                                  string
+		cluster                               string
+		identity                              string
+		enableVSRoutingInCluster              bool
+		enabledVSRoutingInClusterForResources map[string]string
+		expected                              bool
 	}{
 		{
-			name: "Given enableVSRoutingInCluster is false, enabledVSRoutingInClusterForIdentities is empty" +
-				"When DoVSRoutingInClusterForIdentity is called" +
+			name: "Given enableVSRoutingInCluster is false, enabledVSRoutingInClusterForResources is empty" +
+				"When DoVSRoutingInClusterForClusterAndIdentity is called" +
 				"Then it should return false",
-			identity:                               "testIdentity1",
-			enableVSRoutingInCluster:               false,
-			enabledVSRoutingInClusterForIdentities: []string{},
-			expected:                               false,
+			cluster:                               "cluster1",
+			enableVSRoutingInCluster:              false,
+			enabledVSRoutingInClusterForResources: map[string]string{},
+			expected:                              false,
 		},
 		{
-			name: "Given enableVSRoutingInCluster is true, enabledVSRoutingInClusterForIdentities is empty" +
-				"When DoVSRoutingInClusterForIdentity is called" +
+			name: "Given enableVSRoutingInCluster is true, enabledVSRoutingInClusterForResources is empty" +
+				"When DoVSRoutingInClusterForClusterAndIdentity is called" +
 				"Then it should return false",
-			identity:                               "testIdentity1",
-			enableVSRoutingInCluster:               true,
-			enabledVSRoutingInClusterForIdentities: []string{},
-			expected:                               false,
+			cluster:                               "cluster1",
+			identity:                              "identity1",
+			enableVSRoutingInCluster:              true,
+			enabledVSRoutingInClusterForResources: map[string]string{},
+			expected:                              false,
 		},
 		{
-			name: "Given enableVSRoutingInCluster is true, and given cluster doesn't exists in the list" +
-				"When DoVSRoutingInClusterForIdentity is called" +
+			name: "Given enableVSRoutingInCluster is true, and given cluster doesn't exists in the enabledVSRoutingInClusterForResources" +
+				"When DoVSRoutingInClusterForClusterAndIdentity is called" +
 				"Then it should return false",
-			identity:                               "testIdentity2",
-			enableVSRoutingInCluster:               true,
-			enabledVSRoutingInClusterForIdentities: []string{"testIdentity1"},
-			expected:                               false,
+			cluster:                               "cluster2",
+			identity:                              "identity1",
+			enableVSRoutingInCluster:              true,
+			enabledVSRoutingInClusterForResources: map[string]string{"cluster1": "test1"},
+			expected:                              false,
 		},
 		{
-			name: "Given enableVSRoutingInCluster is true, and given cluster does exists in the list" +
-				"When DoVSRoutingInClusterForIdentity is called" +
+			name: "Given enableVSRoutingInCluster is true, and given cluster does exists in the map" +
+				"When DoVSRoutingInClusterForClusterAndIdentity is called" +
 				"Then it should return true",
-			identity:                               "testIdentity1",
-			enableVSRoutingInCluster:               true,
-			enabledVSRoutingInClusterForIdentities: []string{"testIdentity1"},
-			expected:                               true,
+			cluster:                               "cluster1",
+			enableVSRoutingInCluster:              true,
+			enabledVSRoutingInClusterForResources: map[string]string{"cluster1": "*"},
+			expected:                              true,
 		},
 		{
 			name: "Given enableVSRoutingInCluster is true, and all VS routing is enabled in all clusters using '*'" +
-				"When DoVSRoutingInClusterForIdentity is called" +
+				"When DoVSRoutingInClusterForClusterAndIdentity is called" +
 				"Then it should return true",
-			identity:                               "testIdentity1",
-			enableVSRoutingInCluster:               true,
-			enabledVSRoutingInClusterForIdentities: []string{"*"},
-			expected:                               true,
+			cluster:                               "cluster1",
+			enableVSRoutingInCluster:              true,
+			enabledVSRoutingInClusterForResources: map[string]string{"*": "*"},
+			expected:                              true,
+		},
+		{
+			name: "Given enableVSRoutingInCluster is true, and given cluster and identity does exists in the map" +
+				"When DoVSRoutingInClusterForClusterAndIdentity is called" +
+				"Then it should return true",
+			cluster:                               "cluster1",
+			identity:                              "identity1",
+			enableVSRoutingInCluster:              true,
+			enabledVSRoutingInClusterForResources: map[string]string{"cluster1": "identity1, identity2"},
+			expected:                              true,
+		},
+		{
+			name: "Given enableVSRoutingInCluster is true, and given cluster does exists in the map, and given identity does not exists in the map" +
+				"When DoVSRoutingInClusterForClusterAndIdentity is called" +
+				"Then it should return false",
+			cluster:                               "cluster1",
+			identity:                              "identity3",
+			enableVSRoutingInCluster:              true,
+			enabledVSRoutingInClusterForResources: map[string]string{"cluster1": "identity1, identity2"},
+			expected:                              false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			p.EnableVSRoutingInCluster = tc.enableVSRoutingInCluster
-			p.VSRoutingInClusterEnabledIdentities = tc.enabledVSRoutingInClusterForIdentities
+			p.VSRoutingInClusterEnabledResources = tc.enabledVSRoutingInClusterForResources
 			ResetSync()
 			InitializeConfig(p)
 
-			assert.Equal(t, tc.expected, DoVSRoutingInClusterForIdentity(tc.identity))
+			assert.Equal(t, tc.expected, DoVSRoutingInClusterForClusterAndIdentity(tc.cluster, tc.identity))
 		})
 	}
 
@@ -971,58 +884,118 @@ func TestGetResyncIntervals(t *testing.T) {
 	assert.Equal(t, time.Minute, actual.UniversalReconcileInterval)
 }
 
-func TestShouldPerformRollback(t *testing.T) {
+func TestIsVSRoutingInClusterDisabledForCluster(t *testing.T) {
 	p := AdmiralParams{}
 	testCases := []struct {
-		name                        string
-		vsRoutingDisabledClusters   []string
-		vsRoutingDisabledIdentities []string
-		expectedResult              bool
+		name                                string
+		vsRoutingInClusterDisabledResources map[string]string
+		cluster                             string
+		expectedResult                      bool
 	}{
 		{
-			name: "Given empty vs routing disabled cluster and disabled identities" +
-				"When func shouldPerformRollback is called" +
+			name: "Given nil vs routing disabled resources" +
+				"When func IsVSRoutingInClusterDisabledForCluster is called" +
 				"Then the func should return false",
-			expectedResult: false,
+			expectedResult:                      false,
+			vsRoutingInClusterDisabledResources: nil,
 		},
 		{
-			name: "Given empty vs routing disabled cluster" +
-				"And non-empty vs routing disabled identities" +
-				"When func shouldPerformRollback is called" +
-				"Then the func should return true",
-			expectedResult:              true,
-			vsRoutingDisabledIdentities: []string{"identity1", "identity2"},
+			name: "Given empty vs routing disabled resources" +
+				"When func IsVSRoutingInClusterDisabledForCluster is called" +
+				"Then the func should return false",
+			expectedResult:                      false,
+			vsRoutingInClusterDisabledResources: map[string]string{},
 		},
 		{
-			name: "Given non-empty vs routing disabled cluster" +
-				"And empty vs routing disabled identities" +
-				"When func shouldPerformRollback is called" +
-				"Then the func should return true",
-			expectedResult:            true,
-			vsRoutingDisabledClusters: []string{"cluster1", "cluster2"},
+			name: "Given non-empty vs routing disabled resources but for unique identity" +
+				"When func IsVSRoutingInClusterDisabledForCluster is called" +
+				"Then the func should return false",
+			expectedResult:                      false,
+			vsRoutingInClusterDisabledResources: map[string]string{"cluster1": "identity1"},
+			cluster:                             "cluster1",
 		},
 		{
-			name: "Given non-empty vs routing disabled cluster" +
-				"And non-empty vs routing disabled identities" +
-				"When func shouldPerformRollback is called" +
+			name: "Given non-empty vs routing disabled resources for all the cluster identities" +
+				"When func IsVSRoutingInClusterDisabledForCluster is called" +
 				"Then the func should return true",
-			expectedResult:              true,
-			vsRoutingDisabledIdentities: []string{"identity1", "identity2"},
-			vsRoutingDisabledClusters:   []string{"cluster1", "cluster2"},
+			expectedResult:                      true,
+			vsRoutingInClusterDisabledResources: map[string]string{"cluster1": "*"},
+			cluster:                             "cluster1",
+		},
+		{
+			name: "Given non-empty vs routing disabled resources for all the resources" +
+				"When func IsVSRoutingInClusterDisabledForCluster is called" +
+				"Then the func should return true",
+			expectedResult:                      true,
+			vsRoutingInClusterDisabledResources: map[string]string{"*": "*"},
+			cluster:                             "cluster1",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			p.VSRoutingInClusterDisabledClusters = tc.vsRoutingDisabledClusters
-			p.VSRoutingInClusterDisabledIdentities = tc.vsRoutingDisabledIdentities
+			p.VSRoutingInClusterDisabledResources = tc.vsRoutingInClusterDisabledResources
+			ResetSync()
+			InitializeConfig(p)
+			actual := IsVSRoutingInClusterDisabledForCluster(tc.cluster)
+			assert.Equal(t, tc.expectedResult, actual)
+		})
+	}
+}
+
+func TestShouldPerformRollback(t *testing.T) {
+	p := AdmiralParams{}
+	testCases := []struct {
+		name                                string
+		vsRoutingInClusterDisabledResources map[string]string
+		expectedResult                      bool
+	}{
+		{
+			name: "Given nil vs routing disabled cluster resources" +
+				"When func shouldPerformRollback is called" +
+				"Then the func should return false",
+			expectedResult:                      false,
+			vsRoutingInClusterDisabledResources: nil,
+		},
+		{
+			name: "Given empty vs routing disabled resources" +
+				"When func shouldPerformRollback is called" +
+				"Then the func should return false",
+			expectedResult:                      false,
+			vsRoutingInClusterDisabledResources: map[string]string{},
+		},
+		{
+			name: "Given non-empty vs routing disabled resources" +
+				"When func shouldPerformRollback is called" +
+				"Then the func should return true",
+			expectedResult:                      true,
+			vsRoutingInClusterDisabledResources: map[string]string{"cluster1": "identity1", "cluster2": "identity2"},
+		},
+		{
+			name: "Given non-empty vs routing disabled resources, with * as value" +
+				"When func shouldPerformRollback is called" +
+				"Then the func should return true",
+			expectedResult:                      true,
+			vsRoutingInClusterDisabledResources: map[string]string{"cluster1": "*"},
+		},
+		{
+			name: "Given non-empty vs routing disabled resources, and disabled for all the resources" +
+				"When func shouldPerformRollback is called" +
+				"Then the func should return true",
+			expectedResult:                      true,
+			vsRoutingInClusterDisabledResources: map[string]string{"*": "*"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p.VSRoutingInClusterDisabledResources = tc.vsRoutingInClusterDisabledResources
 			ResetSync()
 			InitializeConfig(p)
 			actual := ShouldInClusterVSRoutingPerformRollback()
 			assert.Equal(t, tc.expectedResult, actual)
 		})
 	}
-
 }
 
 //func TestGetCRDIdentityLabelWithLabel(t *testing.T) {

--- a/admiral/pkg/controller/common/types.go
+++ b/admiral/pkg/controller/common/types.go
@@ -145,11 +145,9 @@ type AdmiralParams struct {
 	VSRoutingSlowStartEnabledClusters []string
 
 	// VS Based Routing In-Cluster
-	EnableVSRoutingInCluster             bool
-	VSRoutingInClusterEnabledClusters    []string
-	VSRoutingInClusterEnabledIdentities  []string
-	VSRoutingInClusterDisabledClusters   []string
-	VSRoutingInClusterDisabledIdentities []string
+	EnableVSRoutingInCluster            bool
+	VSRoutingInClusterEnabledResources  map[string]string
+	VSRoutingInClusterDisabledResources map[string]string
 
 	//Client discovery (types requiring mesh egress only)
 	EnableClientDiscovery          bool


### PR DESCRIPTION
### Checklist
🚨 Please review this repository's [contribution guidelines](./CONTRIBUTING.md).

- [X] I've read and agree to the project's contribution guidelines.
- [X] I checked that my code additions will pass code linting checks and unit tests.
- [X] I updated unit and integration tests (if applicable).
- [X] I'm ready to notify the team of this contribution.

### Description
What does this change do and why?
Handle exportTo on in cluster routing vs
Admiral will process all the clusters and all the identities, and create VS with exportTo as "admiral-sync"
Admiral will update the exportTo to the client namespace only for the cluster and identities where VS base in-cluster routing is enabled.

Thank you!