### PR TITLE
made cartographer VS check conditional

### DIFF
--- a/admiral/pkg/clusters/serviceentry.go
+++ b/admiral/pkg/clusters/serviceentry.go
@@ -1571,8 +1571,10 @@ func AddServiceEntriesWithDrWorker(
 		currentDR := getCurrentDRForLocalityLbSetting(rr, isServiceEntryModifyCalledForSourceCluster, cluster, se, partitionedIdentity)
 		ctxLogger.Infof("currentDR set for dr=%v cluster=%v", getIstioResourceName(se.Hosts[0], "-default-dr"), cluster)
 
+		// performCartographerVSCheck is set to true because we need to check if cartographer VS's exportTo
+		// has been modified to dot before pinning the .mesh DR
 		doDRUpdateForInClusterVSRouting := DoDRUpdateForInClusterVSRouting(
-			ctx, ctxLogger, env, cluster, identityId, isServiceEntryModifyCalledForSourceCluster, rr, se)
+			ctx, ctxLogger, env, cluster, identityId, isServiceEntryModifyCalledForSourceCluster, rr, se, true)
 
 		ctxLogger.Infof(
 			common.CtxLogFormat, "AddServiceEntriesWithDrWorker", "", "", cluster,

--- a/admiral/pkg/clusters/virtualservice_routing_test.go
+++ b/admiral/pkg/clusters/virtualservice_routing_test.go
@@ -8713,7 +8713,7 @@ func TestDoDRUpdateForInClusterVSRouting(t *testing.T) {
 			common.InitializeConfig(p)
 
 			assert.Equal(t, tc.expected, DoDRUpdateForInClusterVSRouting(context.Background(),
-				ctxLogger, tc.env, tc.cluster, tc.identity, tc.isSourceCluster, tc.remoteRegistry, tc.serviceEntry))
+				ctxLogger, tc.env, tc.cluster, tc.identity, tc.isSourceCluster, tc.remoteRegistry, tc.serviceEntry, true))
 		})
 	}
 
@@ -8866,6 +8866,7 @@ func TestDoVSRoutingInClusterForClusterAndIdentity(t *testing.T) {
 		vsRoutingInClusterDisabledResources   map[string]string
 		remoteRegistry                        *RemoteRegistry
 		expected                              bool
+		performCartographerVSCheck            bool
 	}{
 		{
 			name: "Given enableVSRoutingInCluster is false, enabledVSRoutingInClusterForResources is empty" +
@@ -8913,6 +8914,7 @@ func TestDoVSRoutingInClusterForClusterAndIdentity(t *testing.T) {
 			enabledVSRoutingInClusterForResources: map[string]string{"cluster9": "*"},
 			remoteRegistry:                        remoteRegistry,
 			expected:                              false,
+			performCartographerVSCheck:            true,
 		},
 		{
 			name: "Given enableVSRoutingInCluster is true, and given cluster does exists in the map" +
@@ -9012,7 +9014,7 @@ func TestDoVSRoutingInClusterForClusterAndIdentity(t *testing.T) {
 			common.InitializeConfig(p)
 
 			assert.Equal(t, tc.expected, DoVSRoutingInClusterForClusterAndIdentity(
-				context.Background(), ctxLogger, tc.env, tc.cluster, tc.identity, tc.remoteRegistry))
+				context.Background(), ctxLogger, tc.env, tc.cluster, tc.identity, tc.remoteRegistry, tc.performCartographerVSCheck))
 		})
 	}
 


### PR DESCRIPTION
made cartographer VS check conditional

The cartographer VS check is only needed to verify if .mesh DR should be pinned. This check is not needed anywhere else.